### PR TITLE
Slab Ocean + Atmos Held-Suarez 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CouplerMachine
 
+Coupler Specific Shared Development
+
 <!-- Links and shortcuts -->
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
 [docs-dev-url]: https://CliMA.github.io/CouplerMachine/dev/
@@ -10,13 +12,13 @@
 [unit-tests-img]: https://github.com/CliMA/CouplerMachine/workflows/Unit%20Tests/badge.svg
 [unit-tests-url]: https://github.com/CliMA/CouplerMachine/actions?query=workflow%3A%22Unit+Tests%22
 
+[codecov-img]: https://codecov.io/gh/CliMA/CouplerMachine/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/CliMA/CouplerMachine
+
 |||
 |---------------------:|:-----------------------------------------------|
-| **Documentation**    | [![dev][docs-dev-img]][docs-dev-url]           |
-| **Docs Build**       | [![docs build][docs-bld-img]][docs-bld-url]    |
-| **Unit Tests**       | [![unit tests][unit-tests-img]][unit-tests-url]|
-
-Coupler Specific Shared Development
+| **Documentation**    | [![dev][docs-dev-img]][docs-dev-url] [![docs build][docs-bld-img]][docs-bld-url]|
+| **Unit Tests**       | [![unit tests][unit-tests-img]][unit-tests-url] [![codecov][codecov-img]][codecov-url]|
 
 Provides coupled system time stepping control and support for mapping import and export
 boundary information between components.

--- a/experiments/SlabOcean/README.md
+++ b/experiments/SlabOcean/README.md
@@ -1,0 +1,164 @@
+# Moist Atmos GCM & Slab Ocean
+
+
+    Two spherical shells:
+
+                |==z = 3e4 m =====
+            A   |                  \\ 
+            T   |      ...           
+            M   |
+            O   |--z = 1e3 m ---  
+            S   |                \
+                |
+                |==z = 0 m ==  
+                              \\
+
+           LAND |==z = 0 m ==
+                              \\
+
+## **Atmos Component**
+
+We use the ClimateMachine.jl's Atmos GCM moist Held-Suarez configuration, with the RQA interface (and the ESDGModel backend), loosely following [Thatcher & Jablonowski (2016)](https://gmd.copernicus.org/articles/9/1263/2016/gmd-9-1263-2016.pdf). We solve six prognostic equations for $ρ$, $ρ\vec{u}$ (3 components), $ρe$ and $ρq$. We solve the linear part (with respect to ρ and ρu) of this set implicitly in order to alleviate problems arising from acoustic and gravity waves, and the rest is solved explicitly using Runge Kutta timestepping. With this ImEx timestepping, the two equation sets we solve are:
+
+### **1. Full model**
+- Equations:
+
+    $$
+    \frac{\partial ρ}{\partial t} + ∇ \cdot (\vec{u} ρ ) = - \max(0, ρq - ρ qᵥ) / τ \qquad 
+    $$
+    $$
+    \frac{\partial \vec{ρu}}{\partial t} + ∇ \cdot (\vec{ρu} \otimes \vec{u} + p I ) = - 2 \Omega  \times ρ\vec{v} - ρ \nabla Φ - k_v ρ\vec{v} \qquad  
+    $$
+    $$
+    \frac{\partial ρe}{\partial t} + ∇ \cdot (\vec{u} (ρe + p)) = - (c_{vl}(T - T_0) + Φ) \max(0, ρq - ρ qᵥ) / τ - k_T ρ c_{vd} (T - T_{equil}) \qquad 
+    $$
+    $$
+    \frac{\partial ρq}{\partial t} + ∇ \cdot (\vec{u} ρq ) = - \max(0, ρq - ρ qᵥ)  / τ \qquad 
+    $$
+    where $I$ is the rank-3 identity matrix, $\vec{v}$ is the horizontal velocity vector, and $T_0 = 273.16 K$. For a more detailed description and values of the parameters above, please see [parameters_initialconditions.jl](parameters_initialconditions.jl). 
+
+- Boundary conditions
+    - Upper (external) boundary:
+        - ρ: `Impenetrable()` 
+        - ρu: `FreeSlip()`
+        - ρe, ρq: `Insulating()`
+    - Lower (coupled) boundary:
+        - ρ: `Impenetrable()`  
+        - ρu: `FreeSlip()`
+        - ρe, ρq: `CoupledPrimary()`: $\frac{\partial θ}{\partial t} = ... - ∇ \cdot F_{tot}$ where $F_{tot}$ is the surface flux calculated by `calculate_land_sfc_fluxes(_...)` using Atmos and Ocean properties (see below) 
+
+                        function numerical_boundary_flux_second_order!(
+                            numerical_flux::Union{PenaltyNumFluxDiffusive},
+                            bctype::CoupledPrimaryBoundary,
+                            balance_law::ModelSetup,
+                            fluxᵀn::Vars, _...)
+                            F_tot = calculate_land_sfc_fluxes(balance_law, state_prognostic⁻, state_auxiliary⁻, t)  # W/m^2
+                            fluxᵀn.ρθ = - F_tot  / balance_law.parameters.cp_d
+
+                        end
+
+        NB: See the [boundary_conditions_doc.md](../../docs/src/boundary_conditions_doc.md) for more details on BCs and their implementation.
+
+### **2. Linear model**
+- Equations
+
+    $$
+    \frac{\partial ρ}{\partial t} + ∇ \cdot (\vec{u} ρ) = 0 \qquad 
+    \frac{\partial \vec{ρu}}{\partial t} + ∇ \cdot p_L  = - ρ \nabla Φ \qquad 
+    \frac{\partial ρe}{\partial t} + ∇ \cdot \frac{(ρeᵣ + pᵣ)  ρu }{ρᵣ} = 0  
+    $$
+
+    where the linear pressure is calculated as
+
+    $$
+    p_L = (c\_p_d / c\_v_d - 1)  (ρe - ρ  Φ - ρe_{latent} + ρ c\_v_d T_0)
+    $$
+    $$
+    ρe_{latent} = (ρq_{tot} - ρq_{liq})  e\_int_{v0} - ρq_{ice}  (e\_int_{v0} + e\_int_{i0})
+    $$
+
+    NB: For a more detailed description and values of the parameters above, please see [parameters_initialconditions.jl](parameters_initialconditions.jl). 
+    
+
+-  Boundary conditions
+    - ρ: `Impenetrable()`; ρu: `FreeSlip()`; ρe, ρq: `Insulating()` for both boundaries
+
+
+## **Slab Ocean Component**
+
+For prototyping of the coupler, we parameterize the land as a 0-dimensional slab covering the whole globe. 
+
+### 1. Formulation
+
+
+$$
+\rho_o h_o c_o \frac{\partial T_{sfc}}{\partial t} = F_{tot} + Q = R_{SW} - R_{LW} - SH - LH + Q
+$$
+
+  
+where
+
+- Sensible heat flux at surface
+    $$SH = ρ C_e |u| c_{vd} (T_{sfc} - T_a)$$
+- Latent heat flux at surface
+    $$LH = ρ C_l |u| L_{Hv0} (q_{sat}(T_{sfc},p_{sfc}) - q_a)$$
+- Downward-pointing short-wave radiative flux
+    $$R_{SW} = F_{sfc}^d - F_{sfc}^u = (1-\alpha)\tau F_{sol} (1 + \sin(2π τ_d^{-1} t))$$
+- Upward-pointing net long-wave flux
+    $$R_{LW} = F_{sfc}^u - F_{sfc}^d = \epsilon \sigma \theta_{sfc}^4 - \epsilon F_{a}$$
+- Ocean mixing processes are parameterized using a time invariant Q-flux (formulation follows the FMS idealized model)
+    $$Q = Q_0\frac{(1-2 \phi^2/L_w^2)}{\cos\phi}exp^{- (\phi^2/L_w^2)}$$
+
+For description and values of the parameters above, please see [parameters_initialconditions.jl](parameters_initialconditions.jl). 
+
+### 2. Implementation
+- for the slab ocean, we use explicit time stepping:
+$$T_{sfc}^{n+1} = T_{sfc}^n +\frac{(F_{tot}^{n} + Q^{n})}{\rho_o c_o h_o}\Delta t$$
+- this is implemented as
+
+        @inline function source!(
+                model::SlabOceanModelSetup, source::Vars, state::Vars, gradflux::Vars, aux::Vars, _...)
+            p = model.parameters
+            Q    =  idealized_qflux(p)
+            source.T_sfc = (aux.F_ρθ_prescribed + Q) / (p.ρ_s * p.c_s * p.h_s)
+        end
+
+## **Coupler**
+
+### 1. Formulation
+- we're using our sequential coupler, which is described [here](https://clima.github.io/CouplerMachine/dev/timestepping/)
+### 2. Surface Flux Handling
+1. Flux calculation
+    - function `calculate_ocean_sfc_fluxes(_...)` is defined in `coupler/surface_fluxes.jl`, and is used for:
+        - the Atmos boundary condition calculation (see above)
+        - for surface flux accumulation (next point). 
+    - it is called by Atmos, which is assumed to be the model with the shortest timestep. This means that the fluxes are only calculated once and are consistent with Atmos's time stepping.
+
+2. Flux accumulation
+    - In order to integrate fluxes in time consistently with the Atmos time stepper, we define a new prognostic variable `F_ρθ_accum` whose source function accumulates the fluxes by integrating them in time, so that $F\_ρθ\_accum = \int F_{tot} dt$.
+
+            @inline function source!(atmos_model::ModelSetup, _...)
+                source.F_ρθ_accum = calculate_ocean_sfc_fluxes(atmos_model, _...) 
+            end
+
+3. Flux / state storage and communication
+    - the coupler stores fields:
+        - `BoundaryEnergyFlux` which collects `F_ρθ_accum / Δt` calculated and accumulated in Atmos during the Atmos part of the coupling cycle (with $Δt$ denoting the period of the coupling cycle), and is called by land for use in its $T_{sfc}$ equation
+        - `SeaSurfaceTemperature` which collects the state of the slab Land model, namely $T_{sfc}$, and is called by atmos when calculating surface fluxes
+
+## **Tests**
+- conservation checks: dry SlabOcean w/o Held-Suarez forcing
+    - [results (June 23 section)](https://docs.google.com/document/d/1JKK8wFKPq3Jo3D4flXZiY3WAUPqYE19pXRvwJgpDwjw/edit)
+- physical checks: moist SlabOcean with Held-Suarez forcing
+    - [results (July 9 section)](https://docs.google.com/document/d/1JKK8wFKPq3Jo3D4flXZiY3WAUPqYE19pXRvwJgpDwjw/edit)
+
+## **Other Notes**
+- diffusion can be added once available in the ESDGModel kernels
+- currently, there is a bug in LMARS numerical fluxes, leading to conservation breaking at the boundary; as an alternative, Roe fluxes can be used (but the moist version is yet to be implemented, and in the dry case Roe fluxes have been found more unstable due to their less extreme smoothing at boundaries)  
+
+## **References**
+- [CESM slab ocean model](https://www.cesm.ucar.edu/models/atm-cam/docs/description/node29.html)
+- [GFDL mixed-layer model](https://www.gfdl.noaa.gov/fms-slab-ocean-model-technical-documentation/)
+- [Bonan 2019 book](https://www.cambridge.org/us/academic/subjects/earth-and-environmental-science/climatology-and-climate-change/climate-change-and-terrestrial-ecosystem-modeling?format=HB&isbn=9781107043787)
+- [Torres et al 19](https://link.springer.com/article/10.1007/s00382-018-4236-x?shared-article-renderer)
+- [Thatcher & Jablonowski (2016)](https://gmd.copernicus.org/articles/9/1263/2016/gmd-9-1263-2016.pdf)

--- a/experiments/SlabOcean/balance_law_interface_slabocean.jl
+++ b/experiments/SlabOcean/balance_law_interface_slabocean.jl
@@ -1,0 +1,187 @@
+import ClimateMachine.BalanceLaws:
+    # declaration
+    vars_state,
+    # initialization
+    init_state_prognostic!,
+    init_state_auxiliary!,
+    nodal_init_state_auxiliary!,
+    # rhs computation
+    compute_gradient_argument!,
+    compute_gradient_flux!,
+    flux_first_order!,
+    flux_second_order!,
+    source!,
+    # boundary conditions
+    boundary_conditions,
+    boundary_state!
+
+import ClimateMachine.DGMethods.NumericalFluxes:
+    CentralNumericalFluxGradient,
+    CentralNumericalFluxSecondOrder,
+    NumericalFluxFirstOrder,
+    NumericalFluxSecondOrder,
+    RusanovNumericalFlux,
+    numerical_boundary_flux_second_order!, 
+    numerical_flux_second_order!, 
+    numerical_boundary_flux_first_order!, 
+    numerical_flux_first_order!,
+    normal_boundary_flux_second_order!
+
+using Unitful
+
+##
+#     Declaration of variables
+##
+"""
+    vars_state 
+    - returns a NamedTuple of data types.
+"""
+function vars_state(model::SlabOceanModelSetup, aux::Auxiliary, T)
+
+    @vars begin
+        x::T
+        y::T
+        z::T
+        F_ρe_prescribed::T # stores prescribed flux for secondary (land import)
+    end
+end
+
+function vars_state(::SlabOceanModelSetup, ::Prognostic, T)
+    @vars begin
+        T_sfc::T
+    end
+end
+
+vars_state(::SlabOceanModelSetup, ::Gradient, T) = @vars()
+
+vars_state(::SlabOceanModelSetup, ::GradientFlux, T) = @vars()
+
+
+##
+#     Initialization of variables
+##
+"""
+    init_state_xyz! 
+    - sets up the initial fields within our state variables
+    (e.g., prognostic, auxiliary, etc.), however it seems to not initialized
+    the gradient flux variables by default.
+"""
+
+function nodal_init_state_auxiliary!(
+    m::SlabOceanModelSetup,
+    state_auxiliary,
+    tmp,
+    geom,
+)
+    init_state_auxiliary!(m, m.physics.orientation, state_auxiliary, geom)
+
+    state_auxiliary.F_ρe_prescribed = 0
+end
+
+function init_state_auxiliary!(
+    ::SlabOceanModelSetup,
+    ::SphericalOrientation,
+    state_auxiliary,
+    geom,
+)
+    FT = eltype(state_auxiliary)
+    r = norm(geom.coord)
+    state_auxiliary.x = geom.coord[1]
+    state_auxiliary.y = geom.coord[2]
+    state_auxiliary.z = geom.coord[3]
+
+end
+
+function init_state_auxiliary!(
+    ::SlabOceanModelSetup,
+    ::Union{NoOrientation,FlatOrientation},
+    state_auxiliary,
+    geom,
+)
+    FT = eltype(state_auxiliary)
+    @inbounds r = geom.coord[3]
+    state_auxiliary.x = geom.coord[1]
+    state_auxiliary.y = geom.coord[2]
+    state_auxiliary.z = geom.coord[3]
+end
+
+function init_state_prognostic!(model::SlabOceanModelSetup, state::Vars, aux::Vars, localgeo, t)
+    x = aux.x
+    y = aux.y
+    z = aux.z
+
+    parameters = model.physics.parameters
+    ic = model.initial_conditions
+
+    FT = eltype(state)
+    state.T_sfc = FT(0)
+    state.T_sfc = ic.T_sfc(parameters, x, y, z)
+
+    return nothing
+end
+
+"""
+    LHS computations
+"""
+flux_first_order!(model::SlabOceanModelSetup, _...,) = nothing
+compute_gradient_argument!(model::SlabOceanModelSetup, _...,) = nothing
+compute_gradient_flux!(model::SlabOceanModelSetup, _...,) = nothing
+flux_second_order!(model::SlabOceanModelSetup, _...,) = nothing
+
+"""
+    RHS computations
+"""
+@inline function source!(
+    model::SlabOceanModelSetup,
+    source::Vars,
+    state::Vars,
+    gradflux::Vars,
+    aux::Vars,
+    t::Real,
+    direction,
+)
+    x = aux.x
+    y = aux.y
+    z = aux.z
+    p = model.physics.parameters
+    FT = eltype(aux)
+
+    Q = FT(0)
+    if boundary_mask(p, x, y, z)
+        Q = idealized_qflux(p, x, y, z) 
+    end    
+
+    source.T_sfc = (aux.F_ρe_prescribed + Q ) / (p.ρ_o * p.c_o * p.h_o)
+
+    return nothing
+end
+
+@inline function idealized_qflux(p, x...)
+    """
+    Calculates additional tropical fluxes for a more realistic representation of surface tropical heating in idealized experiments
+    """
+    FT = eltype(p.Q_0)
+    ϕ = lat(x...)  
+    Q = p.Q_0 * (FT(1) - 2ϕ^2 / p.L_w^2) * exp(- ϕ^2 / p.L_w^2) / cos(ϕ)
+    
+    ϕ_Qcutoff = FT(85 /  180 * pi) # this is not in the GFLD model but here needed to avoid polar discontinuities
+    Q = abs(ϕ) > ϕ_Qcutoff ? FT(0) : Q
+end
+
+"""
+    Numerics and boundary conditions
+    - no interior / exterior interface fluxes needed for the slab
+"""
+@inline boundary_conditions(model::SlabOceanModelSetup) = model.boundary_conditions
+
+numerical_flux_first_order!(::Nothing, model::Union{SlabOceanModelSetup}, _...,) = nothing
+numerical_flux_gradient!(nf, bc,  model::Union{SlabOceanModelSetup}, _...,) = nothing
+function numerical_flux_second_order!(::Nothing, model::Union{SlabOceanModelSetup}, fluxᵀn, _...,)
+    fluxᵀn.T_sfc = fluxᵀn.T_sfc .* Float64(0) # this overwrites the internal numerical flux contributions to the normal flux
+end
+
+numerical_boundary_flux_first_order!(::Nothing, bc, model::Union{SlabOceanModelSetup}, _...,) = nothing
+numerical_boundary_flux_gradient!(::Nothing, bc, model::Union{SlabOceanModelSetup}, _...,) = nothing
+function numerical_boundary_flux_second_order!(::Nothing, bc, model::Union{SlabOceanModelSetup},fluxᵀn, _...,)
+    fluxᵀn.T_sfc = fluxᵀn.T_sfc .* Float64(0) # this overwrites the internal numerical flux contributions to the normal flux
+end

--- a/experiments/SlabOcean/boundary_conditions/boundary_conditions.jl
+++ b/experiments/SlabOcean/boundary_conditions/boundary_conditions.jl
@@ -1,0 +1,144 @@
+abstract type AbstractBoundaryCondition end
+
+struct DefaultBC <: AbstractBoundaryCondition end
+
+Base.@kwdef struct BulkFormulaTemperature{𝒯,𝒰,𝒱} <: AbstractBoundaryCondition 
+  drag_coef_temperature::𝒯
+  drag_coef_moisture::𝒰
+  surface_temperature::𝒱
+end
+
+Base.@kwdef struct CoupledPrimarySlabOceanBC{𝒯,𝒰} <: AbstractBoundaryCondition 
+    drag_coef_temperature::𝒯
+    drag_coef_moisture::𝒰
+end
+
+abstract type TemperatureBC end
+struct Insulating <: TemperatureBC end
+struct CoupledSecondaryAtmosModelBC <: TemperatureBC end
+
+function numerical_boundary_flux_first_order!(
+    numerical_flux::NumericalFluxFirstOrder,
+    ::DefaultBC,
+    balance_law::DryAtmosModel,
+    fluxᵀn::Vars{S},
+    n̂::SVector,
+    state⁻::Vars{S},
+    aux⁻::Vars{A},
+    state⁺::Vars{S},
+    aux⁺::Vars{A},
+    t,
+    direction,
+    state1⁻::Vars{S},
+    aux1⁻::Vars{A},
+) where {S, A}
+    state⁺.ρ = state⁻.ρ
+    state⁺.ρe = state⁻.ρe
+    state⁺.ρq = state⁻.ρq
+
+    # project and reflect for impenetrable condition, but 
+    # leave tangential component untouched
+    ρu⁻ = state⁻.ρu
+    state⁺.ρu = ρu⁻ - 2n̂ ⋅ ρu⁻ .* SVector(n̂) 
+
+    numerical_flux_first_order!(
+      numerical_flux,
+      balance_law,
+      fluxᵀn,
+      n̂,
+      state⁻,
+      aux⁻,
+      state⁺,
+      aux⁺,
+      t,
+      direction,
+    )
+end
+
+function numerical_boundary_flux_first_order!(
+    numerical_flux::NumericalFluxFirstOrder,
+    bctype::BulkFormulaTemperature,
+    model::DryAtmosModel,
+    fluxᵀn::Vars{S},
+    n̂::SVector,
+    state⁻::Vars{S},
+    aux⁻::Vars{A},
+    state⁺::Vars{S},
+    aux⁺::Vars{A},
+    t,
+    direction,
+    state1⁻::Vars{S},
+    aux1⁻::Vars{A},
+) where {S, A}
+    # Impenetrable free-slip condition to reflect and project momentum 
+    # at the boundary
+    numerical_boundary_flux_first_order!(
+        numerical_flux,
+        DefaultBC(),
+        model,
+        fluxᵀn,
+        n̂,
+        state⁻,
+        aux⁻,
+        state⁺,
+        aux⁺,
+        t,
+        direction,
+        state1⁻,
+        aux1⁻,
+    )
+    
+    E, H = calc_ocean_sfc_fluxes(model.physics, bctype, state⁻, aux⁻)
+    LH_v0 = model.physics.parameters.LH_v0
+
+    fluxᵀn.ρ  -= E / LH_v0 
+    fluxᵀn.ρe -= E + H
+    fluxᵀn.ρq -= E / LH_v0
+end
+
+function numerical_boundary_flux_first_order!(
+    numerical_flux::NumericalFluxFirstOrder,
+    bctype::CoupledPrimarySlabOceanBC,
+    model::DryAtmosModel,
+    fluxᵀn::Vars{S},
+    n̂::SVector,
+    state⁻::Vars{S},
+    aux⁻::Vars{A},
+    state⁺::Vars{S},
+    aux⁺::Vars{A},
+    t,
+    direction,
+    state1⁻::Vars{S},
+    aux1⁻::Vars{A},
+) where {S, A}
+    # Impenetrable free-slip condition to reflect and project momentum 
+    # at the boundary
+
+    numerical_boundary_flux_first_order!(
+        numerical_flux,
+        DefaultBC(),
+        model,
+        fluxᵀn,
+        n̂,
+        state⁻,
+        aux⁻,
+        state⁺,
+        aux⁺,
+        t,
+        direction,
+        state1⁻,
+        aux1⁻,
+    )
+    
+    # The following will be moved the the second-order kernel (as a Neumann BC) once available
+    LH_v0 = model.physics.parameters.LH_v0
+    E, H = calc_ocean_sfc_fluxes(model.physics, bctype, state⁻, aux⁻) #[W/m^2]
+
+    fluxᵀn.ρ  -= E / LH_v0 
+    fluxᵀn.ρe -= E + H
+    fluxᵀn.ρq -= E / LH_v0
+
+end
+
+
+

--- a/experiments/SlabOcean/coupler/put_get_calls.jl
+++ b/experiments/SlabOcean/coupler/put_get_calls.jl
@@ -1,0 +1,95 @@
+# Ocean put and get calls
+
+"""
+function preOcean(csolver)
+    - saves and regrids the `BoundaryEnergyFlux` couplerfield (i.e. regridded `mAtmos.state.F_ρθ_accum[mAtmos.boundary]`) to `F_ρθ_prescribed[mOcean.boundary]` on the `mOcean` grid
+    csolver::CplSolver
+"""
+function preOcean(csolver)
+    mOcean = csolver.component_list.domainOcean.component_model
+    mAtmos = csolver.component_list.domainAtmos.component_model
+
+    mOcean.odesolver.rhs!.state_auxiliary.F_ρe_prescribed[mOcean.boundary] .= 
+        coupler_get(csolver.coupler, :BoundaryEnergyFlux, mOcean.grid, DateTime(0), u"J")
+end
+
+"""
+function postOcean(csolver)
+    - updates couplerfield `OceanSurfaceTemerature` with `mOcean.state.T_sfc[mOcean.boundary]` regridded to the coupler grid, and updates the coupler time
+    csolver::CplSolver
+"""
+function postOcean(csolver)
+    mOcean = csolver.component_list.domainOcean.component_model
+    mAtmos = csolver.component_list.domainAtmos.component_model
+    coupler_put!(csolver.coupler, :SeaSurfaceTemerature, mOcean.state.T_sfc[mOcean.boundary], mOcean.grid.numerical, DateTime(0), u"K")
+end
+
+# Atmos put and get calls
+"""
+function preAtmos(csolver)
+    - saves and regrids the `SeaSurfaceTemerature` couplerfield (i.e. regridded `mOcean.state.T_sfc[mOcean.boundary]``) on coupler grid to `mAtmos.aux.T_sfc[mAtmos.boundary]` on the `mAtmos` grid
+    - resets the accumulated flux `F_ρe_accum` in `mAtmos` to 0
+    csolver::CplSolver
+"""
+function preAtmos(csolver)
+    mOcean = csolver.component_list.domainOcean.component_model
+    mAtmos = csolver.component_list.domainAtmos.component_model
+    # Set boundary T_sfc used in atmos at the start of the coupling cycle.
+    mAtmos.odesolver.rhs!.state_auxiliary.T_sfc[mAtmos.boundary] .= 
+        coupler_get(csolver.coupler, :SeaSurfaceTemerature, mAtmos.grid.numerical, DateTime(0), u"K")
+    # Set atmos boundary flux accumulator to 0.
+    mAtmos.state.F_ρe_accum .= 0
+
+    # get indicies of the required variables from the `mAtmos` MPIStateArray
+    idx = varsindex(vars(mAtmos.state), :ρe)[1]
+    idx_rho = varsindex(vars(mAtmos.state), :ρ)[1]
+
+    # Calculate, print and log domain-averaged energy
+    FT = eltype(mAtmos.state)
+
+    model_type = cpl_solver.component_list.domainAtmos.component_model.model[1] # TODO: bl should be more accessible
+    p = model_type.model.physics.parameters # maybe the parameter list could be saved in the coupler? (this would requre all the compute kernels below to import the coupler)
+    nel = mAtmos.grid.resolution.elements.vertical
+    po = mAtmos.grid.resolution.polynomial_order.vertical
+
+    Earth_sfc_area = FT(4π * 6371000.0 ^ 2)
+    ocean_layer_volume = sum((mOcean.state.weights[:,:,mOcean.state.realelems])[mOcean.boundary])
+    E_Ocean = weightedsum(mOcean.state, 1)  .* p.ρ_o .* p.c_o .* p.h_o ./ ocean_layer_volume # J / m^2
+    E_Atmos = weightedsum(mAtmos.state, idx)  ./  Earth_sfc_area  # J / m^2 
+
+    @info(
+        "preatmos",
+        time = string(csolver.t) * "/" * string(mAtmos.time.finish),
+        total_energyA = E_Ocean,
+        total_energyB = E_Atmos,
+        total_energy = E_Atmos + E_Ocean,
+        Ocean_T_sfc = maximum(mOcean.state.T_sfc[mOcean.boundary]),
+        atmos_ρe_sfc = maximum(mAtmos.state.ρe[mAtmos.boundary]),
+    )
+
+    isnothing(csolver.fluxlog) ? nothing : csolver.fluxlog.A[csolver.steps] = E_Ocean
+    isnothing(csolver.fluxlog) ? nothing : csolver.fluxlog.B[csolver.steps] = E_Atmos
+end
+
+"""
+function postAtmos(csolver)
+    - updates couplerfield `BoundaryEnergyFlux` with mAtmos.state.F_ρe_accum[mAtmos.boundary] regridded to the coupler grid, and updates the coupler time
+    csolver::CplSolver
+"""
+function postAtmos(csolver)
+    mOcean = csolver.component_list.domainOcean.component_model
+    mAtmos = csolver.component_list.domainAtmos.component_model
+    
+    # Pass atmos exports to "coupler" namespace
+    # 1. Save mean θ flux at the Atmos boundary during the coupling period
+
+    @info(
+        "postatmos",
+        time = string(csolver.t) * "/" * string(mAtmos.time.finish),
+        Ocean_T_sfc = maximum(mOcean.state.T_sfc[mOcean.boundary]),
+        atmos_ρe_sfc = maximum(mAtmos.state.ρe[mAtmos.boundary]),
+    )
+
+    coupler_put!(csolver.coupler, :BoundaryEnergyFlux, mAtmos.state.F_ρe_accum[mAtmos.boundary] ./ csolver.dt,
+        mAtmos.grid.numerical, DateTime(0), u"J")
+end

--- a/experiments/SlabOcean/coupler/surface_fluxes.jl
+++ b/experiments/SlabOcean/coupler/surface_fluxes.jl
@@ -1,0 +1,96 @@
+
+Base.@kwdef struct FluxAccumulator{B} <: AbstractPhysicsComponent 
+    bctype::B
+end
+
+function calc_component!(
+    source,
+    accumulator::FluxAccumulator,
+    state,
+    aux,
+    physics,)
+    
+    # save flux in atmos source for integration in time using atmos timestepping
+    if boundary_mask(physics.parameters, aux.x, aux.y, aux.z)
+        E, H = calc_ocean_sfc_fluxes(physics, accumulator.bctype, state, aux)
+        source.F_ρe_accum = (E + H) # latent + sensible heat fluxes [W/m^2]
+    end
+end
+
+
+"""
+    calculate_land_sfc_fluxes(model::DryAtmosModel, state, aux)
+- calculate furface fluxes using the bulk gradient diffusion theory
+"""
+
+function calc_ocean_sfc_fluxes(physics, bctype::BulkFormulaTemperature, state⁻, aux⁻)
+    # Apply bulks laws using the tangential velocity as energy flux
+    ρ = state⁻.ρ
+    ρu = state⁻.ρu
+    ρq = state⁻.ρq
+    eos = physics.eos
+    parameters = physics.parameters
+
+    # vertical unit vector
+    n̂ = aux⁻.∇Φ / parameters.g
+
+    # obtain surface fields from bcs
+    ϕ = lat(aux⁻.x, aux⁻.y, aux⁻.z)
+    Cₕ = bctype.drag_coef_temperature(parameters, ϕ)
+    Cₑ = bctype.drag_coef_moisture(parameters, ϕ)
+    T_sfc = bctype.surface_temperature(parameters, ϕ)
+    LH_v0 = parameters.LH_v0
+
+    # magnitude of tangential velocity (usually called speed)
+    u = ρu / ρ
+    speed_tangential = norm((I - n̂ ⊗ n̂) * u)
+    
+    # sensible heat flux
+    cp = calc_heat_capacity_at_constant_pressure(eos, state⁻, parameters)
+    T = calc_air_temperature(eos, state⁻, aux⁻, parameters)
+    H = ρ * Cₕ * speed_tangential * cp * (T_sfc - T)
+
+    # latent heat flux
+    q = ρq / ρ
+    q_tot_sfc  = calc_saturation_specific_humidity(ρ, T_sfc, parameters) 
+    E = ρ * Cₑ * speed_tangential * LH_v0 * (q_tot_sfc - q)
+
+    return E, H
+end
+
+function calc_ocean_sfc_fluxes(physics,bctype::CoupledPrimarySlabOceanBC, state⁻, aux⁻; MO_params = nothing) # should pass in the coupler state (also move to coupler), so can access states of both models derectly -e.g. callback?
+
+    # Apply bulks laws using the tangential velocity as energy flux
+    ρ = state⁻.ρ
+    ρu = state⁻.ρu
+    ρq = state⁻.ρq
+    eos = physics.eos
+    parameters = physics.parameters
+
+    # vertical unit vector
+    n̂ = aux⁻.∇Φ / parameters.g
+
+    # obtain surface fields from bcs
+    Cₕ = parameters.Cₗ
+    Cₑ = parameters.Cₑ
+    LH_v0 = parameters.LH_v0
+    T_sfc = aux⁻.T_sfc
+
+    # magnitude of tangential velocity (usually called speed)
+    u = ρu / ρ
+    speed_tangential = norm((I - n̂ ⊗ n̂) * u)
+        
+    # sensible heat flux
+    cp = calc_heat_capacity_at_constant_pressure(eos, state⁻, parameters)
+    T = calc_air_temperature(eos, state⁻, aux⁻, parameters)
+    H = ρ * Cₕ * speed_tangential * cp * (T_sfc - T)
+
+    # latent heat flux
+    q = ρq / ρ
+    q_tot_sfc  = calc_saturation_specific_humidity(ρ, T_sfc, parameters) 
+    E = ρ * Cₑ * speed_tangential * LH_v0 * (q_tot_sfc - q)
+
+    E = isnan(E) ? zero(E) : E # set the fluxes of the non-sfc layers to 0 (otherwise NaNs if moisture) TODO: if calc_component imports BL, then could apply the FluxAccumulator on the boundary only and this line won't be needed 
+
+    return E, H
+end

--- a/experiments/SlabOcean/domains.jl
+++ b/experiments/SlabOcean/domains.jl
@@ -1,0 +1,135 @@
+using Printf
+
+import Base: getindex, ndims, length, *
+import LinearAlgebra: ×
+
+abstract type AbstractDomain end
+
+"""
+    IntervalDomain
+"""
+struct IntervalDomain{T} <: AbstractDomain
+    min::T
+    max::T
+    periodic::Bool
+end
+
+function IntervalDomain(; min, max, periodic = false)
+    @assert min < max
+    return IntervalDomain(min, max, periodic)
+end
+
+"""
+    ProductDomain
+"""
+struct ProductDomain{T} <: AbstractDomain
+    domains::T
+end
+
+function ProductDomain(; domains)
+    if length(domains) < 2
+        error("A product domain needs more than one subdomain!")
+    else
+        return reduce(×, domains)
+    end
+end
+
+"""
+    SphericalShell
+"""
+struct SphericalShell{T} <: AbstractDomain
+    radius::T
+    height::T
+end
+
+function SphericalShell(; radius, height)
+    @assert radius > 0 && height > 0
+    return SphericalShell(radius, height)
+end
+
+"""
+    SingleStack
+"""
+struct SingleStack{T} <: AbstractDomain
+    hmax::T
+    zmin::T
+    zmax::T
+end
+
+function SingleStack(; hmax, zmin, zmax)
+    return SingleStack(hmax, zmin, zmax)
+end
+
+"""
+    Nary Operations
+"""
+×(domain1::AbstractDomain, domain2::AbstractDomain) = ProductDomain((domain1, domain2))
+×(product::ProductDomain, domain::AbstractDomain) = ProductDomain((product.domains..., domain))
+×(domain::AbstractDomain, product::ProductDomain)  = ProductDomain((domain, product.domains...))
+×(product1::ProductDomain, product2::ProductDomain)  = ProductDomain((product1.domains..., product2.domains...))
+
+"""
+    Extensions
+"""
+Base.ndims(domain::IntervalDomain) = 1
+Base.ndims(domain::ProductDomain)  = +(ndims.(domain.domains)...)
+Base.ndims(domain::SphericalShell) = 3
+
+Base.length(domain::IntervalDomain) = domain.max - domain.min
+Base.length(domain::ProductDomain)  = length.(domain.domains)
+Base.length(domain::SphericalShell) = (domain.radius, domain.radius, domain.height)
+
+Base.getindex(domain::ProductDomain, i::Int) = domain.domains[i]
+
+function Base.getproperty(value::ProductDomain, name::Symbol)
+    if name == :periodicity
+        periodicity = ones(Bool, ndims(value))
+        for i in 1:ndims(value)
+            periodicity[i] = value[i].periodic
+        end
+        return Tuple(periodicity)
+    else
+        # default
+        return getfield(value, name)
+    end
+end
+
+function Base.propertynames(::ProductDomain)
+    return (:domains, :periodicity)
+end
+
+function Base.show(io::IO, domain::IntervalDomain)
+    min = domain.min
+    max = domain.max
+    printstyled(io, "[", color = 226)
+    astring = @sprintf("%0.2f", min)
+    bstring = @sprintf("%0.2f", max)
+    printstyled(astring, ", ", bstring, color = 7)
+    domain.periodic ? printstyled(io, ")", color = 226) :
+    printstyled(io, "]", color = 226)
+end
+
+function Base.show(io::IO, product::ProductDomain)
+    for (i, domain) in enumerate(product.domains)
+        print(domain)
+        if i < ndims(product)
+            printstyled(io, "×", color = 118)
+        end
+    end
+end
+
+function info(domain::ProductDomain)
+    println("This is a ", ndims(domain), "-dimensional tensor product domain.")
+    print("The domain is ")
+    println(domain, ".")
+    for (i, domain) in enumerate(domain.domains)
+        domain_string = domain.periodic ? "periodic" : "wall-bounded"
+        length = @sprintf("%.2f ", domain.max - domain.min)
+        println(
+            "The dimension $i domain is ",
+            domain_string,
+            " with length ≈ ",
+            length,
+        )
+    end
+end

--- a/experiments/SlabOcean/esdg_balance_law_interface.jl
+++ b/experiments/SlabOcean/esdg_balance_law_interface.jl
@@ -1,0 +1,228 @@
+import ClimateMachine.BalanceLaws:
+    # declaration
+    vars_state,
+    # initialization
+    nodal_init_state_auxiliary!,
+    init_state_prognostic!,
+    init_state_auxiliary!,
+    # rhs computation
+    compute_gradient_argument!,
+    compute_gradient_flux!,
+    flux_first_order!,
+    flux_second_order!,
+    source!,
+    # boundary conditions
+    boundary_conditions,
+    boundary_state!
+import ClimateMachine.NumericalFluxes:
+    numerical_boundary_flux_first_order!
+
+struct DryReferenceState{TP}
+    temperature_profile::TP
+end
+
+"""
+    Declaration of state variables
+    vars_state returns a NamedTuple of data types.
+"""
+function vars_state(m::DryAtmosModel, st::Auxiliary, FT)
+    @vars begin
+        x::FT
+        y::FT
+        z::FT
+        Φ::FT
+        ∇Φ::SVector{3, FT} # TODO: only needed for the linear model
+        ref_state::vars_state(m, m.physics.ref_state, st, FT)
+        T_sfc::FT  # Ocean surface temperature
+    end
+end
+
+vars_state(::DryAtmosModel, ::DryReferenceState, ::Auxiliary, FT) =
+    @vars(T::FT, p::FT, ρ::FT, ρu::SVector{3, FT}, ρe::FT, ρq::FT)
+vars_state(::DryAtmosModel, ::NoReferenceState, ::Auxiliary, FT) = @vars()
+
+function vars_state(::DryAtmosModel, ::Prognostic, FT)
+    @vars begin
+        ρ::FT
+        ρu::SVector{3, FT}
+        ρe::FT
+        ρq::FT
+        F_ρe_accum::FT # accumulated energy flux
+    end
+end
+
+""" 
+    Initialization of state variables
+    init_state_xyz! sets up the initial fields within our state variables
+    (e.g., prognostic, auxiliary, etc.), however it seems to not initialized
+    the gradient flux variables by default.
+"""
+function init_state_prognostic!(
+        model::DryAtmosModel,
+        state::Vars,
+        aux::Vars,
+        localgeo,
+        t
+    )
+    x = aux.x
+    y = aux.y
+    z = aux.z
+
+    parameters = model.physics.parameters
+    ic = model.initial_conditions
+
+    # TODO!: Set to 0 by default or assign IC
+    if !isnothing(ic)
+        state.ρ  = ic.ρ(parameters, x, y, z)
+        state.ρu = ic.ρu(parameters, x, y, z)
+        state.ρe = ic.ρe(parameters, x, y, z)
+        state.ρq = ic.ρq(parameters, x, y, z)
+    end
+
+    state.F_ρe_accum = 0    
+
+    return nothing
+end
+
+function nodal_init_state_auxiliary!(
+    model::DryAtmosModel,
+    state_auxiliary,
+    tmp,
+    geom,
+)
+    init_state_auxiliary!(model, model.physics.orientation, state_auxiliary, geom)
+    init_state_auxiliary!(model, model.physics.ref_state, state_auxiliary, geom)
+
+    FT = eltype(state_auxiliary)
+    state_auxiliary.T_sfc = FT(0) # otherwise can get NaNs if only the boundary of the MPIStateArray is allocated
+end
+
+function init_state_auxiliary!(
+    model::DryAtmosModel,
+    ::SphericalOrientation,
+    state_auxiliary,
+    geom,
+)
+    g = model.physics.parameters.g
+
+    r = norm(geom.coord)
+    state_auxiliary.x = geom.coord[1]
+    state_auxiliary.y = geom.coord[2]
+    state_auxiliary.z = geom.coord[3]
+    state_auxiliary.Φ = g * r
+    state_auxiliary.∇Φ = g * geom.coord / r
+end
+
+function init_state_auxiliary!(
+    model::DryAtmosModel,
+    ::FlatOrientation,
+    state_auxiliary,
+    geom,
+)
+    g = model.physics.parameters.g
+
+    FT = eltype(state_auxiliary)
+    
+    r = geom.coord[3]
+    state_auxiliary.x = geom.coord[1]
+    state_auxiliary.y = geom.coord[2]
+    state_auxiliary.z = geom.coord[3]
+    state_auxiliary.Φ = g * r
+    state_auxiliary.∇Φ = SVector{3, FT}(0, 0, g)
+end
+
+function init_state_auxiliary!(
+    ::DryAtmosModel,
+    ::NoReferenceState,
+    state_auxiliary,
+    geom,
+) end
+
+function init_state_auxiliary!(
+    model::DryAtmosModel,
+    ref_state::DryReferenceState,
+    state_auxiliary,
+    geom,
+)
+    orientation = model.physics.orientation   
+    R_d         = model.physics.parameters.R_d
+    γ           = model.physics.parameters.γ
+    Φ           = state_auxiliary.Φ
+
+    FT = eltype(state_auxiliary)
+
+    # Calculation of a dry reference state
+    z = altitude(model, orientation, geom)
+    T, p = ref_state.temperature_profile(model.physics.parameters, z)
+    ρ  = p / R_d / T
+    ρu = SVector{3, FT}(0, 0, 0)
+    ρe = p / (γ - 1) + dot(ρu, ρu) / 2ρ + ρ * Φ
+    ρq = FT(0)
+
+    state_auxiliary.ref_state.T  = T
+    state_auxiliary.ref_state.p  = p
+    state_auxiliary.ref_state.ρ  = ρ
+    state_auxiliary.ref_state.ρu = ρu
+    state_auxiliary.ref_state.ρe = ρe
+    state_auxiliary.ref_state.ρq = ρq    
+end
+
+"""
+    LHS computations
+"""
+@inline function flux_first_order!(
+    model::DryAtmosModel,
+    flux::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+    direction,
+)
+    lhs = model.physics.lhs
+    physics = model.physics
+    
+    ntuple(Val(length(lhs))) do s
+        Base.@_inline_meta
+        calc_component!(flux, lhs[s], state, aux, physics)
+    end
+end
+
+"""
+    RHS computations
+"""
+function source!(
+    model::DryAtmosModel, 
+    source, 
+    state_prognostic, 
+    state_auxiliary, 
+    _...
+)
+    sources = model.physics.sources
+    physics = model.physics
+
+    ntuple(Val(length(sources))) do s
+        Base.@_inline_meta
+        calc_component!(source, sources[s], state_prognostic, state_auxiliary, physics)
+    end
+
+end
+
+"""
+    Boundary conditions with defaults
+"""
+boundary_conditions(model::DryAtmosModel) = model.boundary_conditions
+
+function boundary_state!(::CentralNumericalFluxSecondOrder,_...)
+    nothing
+end
+
+"""
+    Utils
+"""
+function altitude(model::DryAtmosModel, ::SphericalOrientation, geom)
+    return norm(geom.coord) - model.physics.parameters.a
+end
+
+function altitude(::DryAtmosModel, ::FlatOrientation, geom)
+    @inbounds geom.coord[3]
+end

--- a/experiments/SlabOcean/grid/domains.jl
+++ b/experiments/SlabOcean/grid/domains.jl
@@ -1,0 +1,136 @@
+using Printf
+
+import Base: getindex, ndims, length, *
+import LinearAlgebra: ×
+
+abstract type AbstractDomain end
+
+"""
+    IntervalDomain
+"""
+struct IntervalDomain{T} <: AbstractDomain
+    min::T
+    max::T
+    periodic::Bool
+end
+
+function IntervalDomain(; min, max, periodic = false)
+    @assert min < max
+    return IntervalDomain(min, max, periodic)
+end
+
+"""
+    ProductDomain
+"""
+struct ProductDomain{T} <: AbstractDomain
+    domains::T
+end
+
+function ProductDomain(; domains)
+    if length(domains) < 2
+        error("A product domain needs more than one subdomain!")
+    else
+        return reduce(×, domains)
+    end
+end
+
+"""
+    SphericalShell
+"""
+struct SphericalShell{T} <: AbstractDomain
+    radius::T
+    height::T
+end
+
+function SphericalShell(; radius, height)
+    @assert radius > 0 && height > 0
+    return SphericalShell(radius, height)
+end
+
+"""
+    SingleStack
+"""
+struct SingleStack{T} <: AbstractDomain
+    zmin::T
+    xmax::T
+    ymax::T
+    zmax::T
+end
+
+function SingleStack(; zmin, xmax,ymax,zmax)
+    return SingleStack(zmin, xmax,ymax,zmax)
+end
+
+"""
+    Nary Operations
+"""
+×(domain1::AbstractDomain, domain2::AbstractDomain) = ProductDomain((domain1, domain2))
+×(product::ProductDomain, domain::AbstractDomain) = ProductDomain((product.domains..., domain))
+×(domain::AbstractDomain, product::ProductDomain)  = ProductDomain((domain, product.domains...))
+×(product1::ProductDomain, product2::ProductDomain)  = ProductDomain((product1.domains..., product2.domains...))
+
+"""
+    Extensions
+"""
+Base.ndims(domain::IntervalDomain) = 1
+Base.ndims(domain::ProductDomain)  = +(ndims.(domain.domains)...)
+Base.ndims(domain::SphericalShell) = 3
+
+Base.length(domain::IntervalDomain) = domain.max - domain.min
+Base.length(domain::ProductDomain)  = length.(domain.domains)
+Base.length(domain::SphericalShell) = (domain.radius, domain.radius, domain.height)
+
+Base.getindex(domain::ProductDomain, i::Int) = domain.domains[i]
+
+function Base.getproperty(value::ProductDomain, name::Symbol)
+    if name == :periodicity
+        periodicity = ones(Bool, ndims(value))
+        for i in 1:ndims(value)
+            periodicity[i] = value[i].periodic
+        end
+        return Tuple(periodicity)
+    else
+        # default
+        return getfield(value, name)
+    end
+end
+
+function Base.propertynames(::ProductDomain)
+    return (:domains, :periodicity)
+end
+
+function Base.show(io::IO, domain::IntervalDomain)
+    min = domain.min
+    max = domain.max
+    printstyled(io, "[", color = 226)
+    astring = @sprintf("%0.2f", min)
+    bstring = @sprintf("%0.2f", max)
+    printstyled(astring, ", ", bstring, color = 7)
+    domain.periodic ? printstyled(io, ")", color = 226) :
+    printstyled(io, "]", color = 226)
+end
+
+function Base.show(io::IO, product::ProductDomain)
+    for (i, domain) in enumerate(product.domains)
+        print(domain)
+        if i < ndims(product)
+            printstyled(io, "×", color = 118)
+        end
+    end
+end
+
+function info(domain::ProductDomain)
+    println("This is a ", ndims(domain), "-dimensional tensor product domain.")
+    print("The domain is ")
+    println(domain, ".")
+    for (i, domain) in enumerate(domain.domains)
+        domain_string = domain.periodic ? "periodic" : "wall-bounded"
+        length = @sprintf("%.2f ", domain.max - domain.min)
+        println(
+            "The dimension $i domain is ",
+            domain_string,
+            " with length ≈ ",
+            length,
+        )
+    end
+end

--- a/experiments/SlabOcean/grid/grid_notes.jl
+++ b/experiments/SlabOcean/grid/grid_notes.jl
@@ -1,0 +1,38 @@
+# the grid data structure contains 37 members
+# (6) Surface structures
+# sgeo, and the 5 ids
+# (17) Volume structures
+# vgeo, and the 16 ids
+# (2) Volume to Surface index
+# vmap⁻, vmap⁺
+# (1) Topology
+# topology
+# (3) Operators
+# grid.D (differentiation matrix), grid.Imat (integration matrix?), grid.ω (quadrature weights)
+# information (1)
+# activedofs (active degrees of freedom)
+# Domain Boundary Information (1)
+# elemtobndy (element to boundary)
+# MPI stuff (6)
+# interiorelems, exteriorelems, nabrtovmaprecv, nabrtovmapsend, vmaprecv, vmapsendv 
+
+# sgeo, the first index is for the ids
+# the second index are the gauss-lobatto entries
+# the third index is the face
+# the last index is the element
+# the ids are: (1, n1id), (2 n2id), (3 n3id) (4, sMid), (5, vMIid)
+# grid.sgeo[1,:,:,:] are normals in the n1 direction
+# norm(grid.vgeo[:, grid.MIid, :][grid.vmap⁻] - grid.sgeo[5,:,:,:]) is zero
+# x[grid.vmap⁻[10]] is connected to x[grid.vmap⁺[10]]
+
+# vgeo, first index is guass-lobatto points
+# second index is ids
+# third index is elements
+# the are are 16 ids
+# 1-9 are metric terms
+# 10 is the mass matrix
+# 11 is the inverse mass matrix
+# 12 is MHid (horizontal mass matrix?)
+# 13-15 are x1 x2 x3
+# 16 is the vertical volume jacobian
+# grid.vgeo[:, grid.ξ1x1id, :]

--- a/experiments/SlabOcean/grid/grids.jl
+++ b/experiments/SlabOcean/grid/grids.jl
@@ -1,0 +1,329 @@
+import ClimateMachine.Mesh.Grids: DiscontinuousSpectralElementGrid
+
+abstract type AbstractDiscretizedDomain end
+
+"""
+    DiscretizedDomain
+"""
+struct DiscretizedDomain{𝒜, ℬ, 𝒞} <: AbstractDiscretizedDomain
+    domain::𝒜
+    resolution::ℬ
+    numerical::𝒞
+end
+
+function DiscretizedDomain(
+    domain::ProductDomain;
+    elements = nothing,
+    polynomial_order = nothing,
+    overintegration_order = nothing,
+    FT = Float64,
+    mpicomm = MPI.COMM_WORLD,
+    array = ClimateMachine.array_type(),
+    topology = StackedBrickTopology,
+    brick_builder = uniform_brick_builder,
+)
+
+    grid = DiscontinuousSpectralElementGrid(
+        domain,
+        elements = elements,
+        polynomialorder = polynomial_order .+ overintegration_order,
+        FT = FT,
+        mpicomm = mpicomm,
+        array = array,
+        topology = topology,
+        brick_builder = brick_builder,
+    )
+    return DiscretizedDomain(
+        domain,
+        (; elements, polynomial_order, overintegration_order),
+        grid,
+    )
+end
+
+function DiscretizedDomain(
+    domain::SphericalShell;
+    elements = nothing,
+    polynomial_order = nothing,
+    overintegration_order = nothing,
+    FT = Float64,
+    mpicomm = MPI.COMM_WORLD,
+    array = ClimateMachine.array_type()
+)
+    new_polynomial_order = convention(polynomial_order, Val(2))
+    new_polynomial_order = new_polynomial_order .+ convention(overintegration_order, Val(2))
+    horizontal, vertical = new_polynomial_order
+
+    grid = DiscontinuousSpectralElementGrid(
+        domain,
+        elements = elements,
+        polynomialorder = (; vertical, horizontal),
+        FT = FT,
+        mpicomm = mpicomm,
+        array = array,
+    )
+    return DiscretizedDomain(
+        domain,
+        (; elements, polynomial_order, overintegration_order),
+        grid,
+    )
+end
+
+function DiscretizedDomain(
+    domain::SingleStack;
+    elements = nothing,
+    polynomial_order = nothing,
+    overintegration_order = nothing,
+    FT = Float64,
+    mpicomm = MPI.COMM_WORLD,
+    array = ClimateMachine.array_type()
+)
+    new_polynomial_order = convention(polynomial_order, Val(2))
+    new_polynomial_order = new_polynomial_order .+ convention(overintegration_order, Val(2))
+    horizontal, vertical = new_polynomial_order
+
+    grid = DiscontinuousSpectralElementGrid(
+        domain,
+        elements = elements,
+        polynomialorder = (; vertical, horizontal),
+        FT = FT,
+        mpicomm = mpicomm,
+        array = array,
+    )
+    return DiscretizedDomain(
+        domain,
+        (; elements, polynomial_order, overintegration_order),
+        grid,
+    )
+end
+
+"""
+function DiscontinuousSpectralElementGrid(domain::ProductDomain; elements = nothing, polynomialorder = nothing)
+# Description 
+Computes a DiscontinuousSpectralElementGrid as specified by a product domain
+# Arguments
+-`domain`: A product domain object
+# Keyword Arguments 
+-`elements`: A tuple of integers ordered by (Nx, Ny, Nz) for number of elements
+-`polynomialorder`: A tupe of integers ordered by (npx, npy, npz) for polynomial order
+-`FT`: floattype, assumed Float64 unless otherwise specified
+-`topology`: default = StackedBrickTopology
+-`mpicomm`: default = MPI.COMM_WORLD
+-`array`: default = ClimateMachine.array_type()
+-`brickbuilder`: default = uniform_brick_builder, 
+  brickrange=uniform_brick_builder(domain, elements)
+# Return 
+A DiscontinuousSpectralElementGrid object
+"""
+function DiscontinuousSpectralElementGrid(
+    domain::ProductDomain;
+    elements,
+    polynomialorder,
+    FT = Float64,
+    mpicomm = MPI.COMM_WORLD,
+    array = ClimateMachine.array_type(),
+    topology = StackedBrickTopology,
+    brick_builder = uniform_brick_builder,
+)
+
+    if elements === nothing
+        error_message = "Please specify the number of elements as a tuple whose size is commensurate with the domain,"
+        error_message *= " e.g., a 3 dimensional domain would need a specification like elements = (10,10,10)."
+        error_message *= " or elements = (vertical = 8, horizontal = 5)"
+
+        @error(error_message)
+        return nothing
+    end
+
+    if polynomialorder === nothing
+        error_message = "Please specify the polynomial order as a tuple whose size is commensurate with the domain,"
+        error_message *= "e.g., a 3 dimensional domain would need a specification like polynomialorder = (3,3,3)."
+        error_message *= " or polynomialorder = (vertical = 8, horizontal = 5)"
+
+        @error(error_message)
+        return nothing
+    end
+
+    dimension = ndims(domain)
+
+    if (dimension < 2) || (dimension > 3)
+        error_message = "SpectralElementGrid only works with dimensions 2 or 3. "
+        error_message *= "The current dimension is " * string(ndims(domain))
+
+        println("The domain is ", domain)
+        @error(error_message)
+        return nothing
+    end
+
+    elements = convention(elements, Val(dimension))
+    if ndims(domain) != length(elements)
+        @error("Incorrectly specified elements for the dimension of the domain")
+        return nothing
+    end
+
+    polynomialorder = convention(polynomialorder, Val(dimension))
+    if ndims(domain) != length(polynomialorder)
+        @error("Incorrectly specified polynomialorders for the dimension of the domain")
+        return nothing
+    end
+
+    brickrange = brick_builder(domain, elements, FT = FT)
+
+    if dimension == 2
+        boundary = ((1, 2), (3, 4))
+    else
+        boundary = ((1, 2), (3, 4), (5, 6))
+    end
+
+    periodicity = domain.periodicity
+    connectivity = dimension == 2 ? :face : :full
+
+    topl = topology(
+        mpicomm,
+        brickrange;
+        periodicity = periodicity,
+        boundary = boundary,
+        connectivity = connectivity,
+    )
+
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = array,
+        polynomialorder = polynomialorder,
+    )
+
+    return grid
+end
+
+function DiscontinuousSpectralElementGrid(
+    domain::SphericalShell;
+    elements,
+    polynomialorder,
+    mpicomm = MPI.COMM_WORLD,
+    boundary = (1,2),
+    FT = Float64,
+    array = Array,
+)
+    Rrange = grid1d(
+        domain.radius, 
+        domain.radius + domain.height, 
+        nelem = elements.vertical
+    )
+
+    topl = StackedCubedSphereTopology(
+        mpicomm,
+        elements.horizontal,
+        Rrange;
+        boundary = boundary,
+    )
+
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = array,
+        polynomialorder = (
+          polynomialorder.horizontal, 
+          polynomialorder.vertical
+       ),
+        meshwarp = equiangular_cubed_sphere_warp,
+    )
+    return grid
+end
+
+"""
+function DiscontinuousSpectralElementGrid(
+    domain::SingleStack;
+"""
+function DiscontinuousSpectralElementGrid(
+    domain::SingleStack;
+    elements,
+    polynomialorder,
+    mpicomm = MPI.COMM_WORLD,
+    boundary = ((0, 0), (0, 0), (5, 6)),
+    periodicity = (true, true, false),
+    meshwarp = (x...) -> identity(x),
+    FT = Float64,
+    array = Array,
+)
+    xmin, xmax = zero(FT), domain.xmax
+    ymin, ymax = zero(FT), domain.ymax
+
+    zmin, zmax = (domain.zmin, domain.zmax)
+
+    brickrange = (
+        grid1d(xmin, xmax, nelem = elements.horizontal),
+        grid1d(ymin, ymax, nelem = elements.horizontal),
+        grid1d(zmin, zmax, nelem = elements.vertical),
+    )
+
+    topl = StackedBrickTopology(
+        mpicomm,
+        brickrange,
+        periodicity = periodicity,
+        boundary = boundary,
+    )
+
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = array,
+        polynomialorder = (
+          polynomialorder.horizontal, 
+          polynomialorder.vertical ),
+        meshwarp = meshwarp,
+    
+    )
+    return grid
+end
+
+
+"""
+    Brick builder
+"""
+function uniform_brick_builder(domain::ProductDomain, elements; FT = Float64)
+    dimension = ndims(domain)
+
+    tuple_ranges = []
+    for i in 1:dimension
+        push!(
+            tuple_ranges,
+            range(
+                FT(domain[i].min);
+                length = elements[i] + 1,
+                stop = FT(domain[i].max),
+            ),
+        )
+    end
+
+    brickrange = Tuple(tuple_ranges)
+    return brickrange
+end
+
+"""
+    Conventions for polynomial order and overintegration order 
+"""
+function convention(
+    a::NamedTuple{(:vertical, :horizontal), T},
+    ::Val{3},
+) where {T}
+    return (a.horizontal, a.horizontal, a.vertical)
+end
+
+function convention(a::Number, ::Val{3})
+    return (a, a, a)
+end
+
+function convention(
+    a::NamedTuple{(:vertical, :horizontal), T},
+    ::Val{2},
+) where {T}
+    return (a.horizontal, a.vertical)
+end
+
+function convention(a::Number, ::Val{2})
+    return (a, a)
+end
+
+function convention(a::Tuple, b)
+    return a
+end

--- a/experiments/SlabOcean/grid/orientations.jl
+++ b/experiments/SlabOcean/grid/orientations.jl
@@ -1,0 +1,63 @@
+using ClimateMachine.Orientations
+
+import ClimateMachine.Orientations: vertical_unit_vector
+
+function orientation_gradient(
+    model::AbstractFluidModel,
+    ::Orientation,
+    state_auxiliary,
+    grid,
+    direction,
+)
+    auxiliary_field_gradient!(
+        model,
+        state_auxiliary,
+        ("orientation.∇Φ",),
+        state_auxiliary,
+        ("orientation.Φ",),
+        grid,
+        direction,
+    )
+
+    return nothing
+end
+
+function orientation_gradient(::AbstractFluidModel, ::NoOrientation, _...)
+    return nothing
+end
+
+function orientation_nodal_init_aux!(
+    ::NoOrientation,
+    # domain::AbstractDomain,
+    aux::Vars,
+    geom::LocalGeometry,
+)
+    return nothing
+end
+
+function orientation_nodal_init_aux!(
+    ::FlatOrientation,
+    # domain::AbstractDomain,
+    aux::Vars,
+    geom::LocalGeometry,
+)
+    @inbounds aux.orientation.Φ = geom.coord[3]
+
+    return nothing
+end
+
+function orientation_nodal_init_aux!(
+    ::SphericalOrientation,
+    # domain::AbstractDomain,
+    aux::Vars,
+    geom::LocalGeometry,
+)
+    norm_R = norm(geom.coord)
+    # @inbounds aux.orientation.Φ = norm_R - domain.radius
+    @inbounds aux.orientation.Φ = norm_R 
+
+    return nothing
+end
+
+@inline vertical_unit_vector(::Orientation, aux) = aux.orientation.∇Φ
+@inline vertical_unit_vector(::NoOrientation, aux) = @SVector [0, 0, 1]

--- a/experiments/SlabOcean/models/models.jl
+++ b/experiments/SlabOcean/models/models.jl
@@ -1,0 +1,98 @@
+using ClimateMachine.BalanceLaws
+
+abstract type AbstractFluidModel <: BalanceLaw end
+
+"""
+    ModelSetup <: AbstractFluidModel
+"""
+struct ModelSetup{𝒯,𝒰,𝒱,𝒲} <: AbstractFluidModel
+    physics::𝒯
+    boundary_conditions::𝒰
+    initial_conditions::𝒱
+    numerics::𝒲
+end
+
+function ModelSetup(;
+    physics,
+    boundary_conditions,
+    initial_conditions,
+    numerics,
+)
+    return ModelSetup(
+        physics,
+        unpack_boundary_conditions(boundary_conditions),
+        initial_conditions,
+        numerics,
+    )
+end
+
+struct SlabOceanModelSetup{𝒯,𝒰,𝒱,𝒲} <: AbstractFluidModel
+    physics::𝒯
+    boundary_conditions::𝒰
+    initial_conditions::𝒱
+    numerics::𝒲
+    #parameters::𝒳
+end
+
+function SlabOceanModelSetup(;
+    physics,
+    boundary_conditions,
+    initial_conditions,
+    numerics,
+    #parameters,
+)
+    
+
+    # boundaries = (:west, :east, :south, :north, :bottom, :top)
+    # repackaged_bcs = []
+    
+    # for boundary in boundaries
+    #     fields = get(boundary_conditions, boundary, nothing)
+    #     new_bc = isnothing(fields) ? Insulating() : fields
+    #     push!(repackaged_bcs, new_bc)
+    # end
+
+    # return SlabOceanModelSetup(
+    #     physics,
+    #     Tuple(repackaged_bcs),
+    #     initial_conditions,
+    #     numerics,
+    #     #parameters,
+    # )
+
+    return SlabOceanModelSetup(
+        physics,
+        boundary_conditions,
+        initial_conditions,
+        numerics,
+        #parameters,
+    )
+
+end
+
+"""
+    DryAtmosModel <: AbstractFluidModel
+
+    temporarily use this struct
+"""
+Base.@kwdef struct DryAtmosModel{𝒯,𝒰,𝒱,𝒲} <: AbstractFluidModel
+    physics::𝒯
+    boundary_conditions::𝒰
+    initial_conditions::𝒱
+    numerics::𝒲
+end
+
+function unpack_boundary_conditions(bcs)
+    # We need to repackage the boundary conditions to match the
+    # boundary conditions interface of the Balance Law and DGModel
+    boundaries = (:west, :east, :south, :north, :bottom, :top)
+    repackaged_bcs = []
+
+    for boundary in boundaries
+        fields = get(bcs, boundary, nothing)
+        new_bc = isnothing(fields) ? FluidBC() : FluidBC(fields...)
+        push!(repackaged_bcs, new_bc)
+    end
+
+    return Tuple(repackaged_bcs)
+end

--- a/experiments/SlabOcean/numerics/filters.jl
+++ b/experiments/SlabOcean/numerics/filters.jl
@@ -1,0 +1,319 @@
+using ClimateMachine.Mesh.Filters
+using KernelAbstractions
+using KernelAbstractions.Extras: @unroll
+
+import ClimateMachine.Mesh.Filters: apply_async!
+import ClimateMachine.Mesh.Filters: AbstractFilterTarget
+import ClimateMachine.Mesh.Filters: number_state_filtered, vars_state_filtered, compute_filter_argument!, compute_filter_result!
+
+function modified_filter_matrix(r, Nc, σ)
+    N = length(r) - 1
+    T = eltype(r)
+
+    @assert N >= 0
+    @assert 0 <= Nc 
+
+    a, b = GaussQuadrature.legendre_coefs(T, N)
+    V = (N == 0 ? ones(T, 1, 1) : GaussQuadrature.orthonormal_poly(r, a, b))
+
+    Σ = ones(T, N + 1) 
+    if Nc ≤ N
+        Σ[(Nc:N) .+ 1] .= σ.(((Nc:N) .- Nc) ./ (N - Nc))
+    end
+
+    V * Diagonal(Σ) / V
+end
+
+abstract type AbstractMassPreservingSpectralFilter <: AbstractSpectralFilter end
+"""
+    CutoffFilter(grid, Nc=polynomialorders(grid))
+Returns the spectral filter that zeros out polynomial modes greater than or
+equal to `Nc`.
+"""
+struct MassPreservingCutoffFilter{FM} <: AbstractMassPreservingSpectralFilter
+    "filter matrices in all directions (tuple of filter matrices)"
+    filter_matrices::FM
+
+    function MassPreservingCutoffFilter(grid, Nc = polynomialorders(grid))
+        dim = dimensionality(grid)
+
+        # Support different filtering thresholds in different
+        # directions (default behavior is to apply the same threshold
+        # uniformly in all directions)
+        if Nc isa Integer
+            Nc = ntuple(i -> Nc, dim)
+        elseif Nc isa NTuple{2} && dim == 3
+            Nc = (Nc[1], Nc[1], Nc[2])
+        end
+        @assert length(Nc) == dim
+
+        # Tuple of polynomial degrees (N₁, N₂, N₃)
+        N = polynomialorders(grid)
+        # In 2D, we assume same polynomial order in the horizontal
+        @assert dim == 2 || N[1] == N[2]
+        @assert all(0 .<= Nc )
+
+        σ(η) = 0
+
+        AT = arraytype(grid)
+        ξ = referencepoints(grid)
+        filter_matrices =
+            ntuple(i -> AT(modified_filter_matrix(ξ[i], Nc[i], σ)), dim)
+        new{typeof(filter_matrices)}(filter_matrices)
+    end
+end
+
+
+function apply_async!(
+    Q,
+    target::AbstractFilterTarget,
+    grid::DiscontinuousSpectralElementGrid,
+    filter::MassPreservingCutoffFilter;
+    dependencies,
+    state_auxiliary = nothing,
+    direction = EveryDirection(),
+)
+    topology = grid.topology
+
+    device = typeof(Q.data) <: Array ? CPU() : CUDADevice()
+
+    dim = dimensionality(grid)
+    N = polynomialorders(grid)
+    # Currently only support same polynomial in both horizontal directions
+    @assert dim == 2 || N[1] == N[2]
+    Nq = N .+ 1
+    Nq1 = Nq[1]
+    Nq2 = Nq[2]
+    Nq3 = dim == 2 ? 1 : Nq[dim]
+
+    nrealelem = length(topology.realelems)
+    # parallel sum info
+    nreduce = 2^ceil(Int, log2(Nq1 * Nq2 * Nq3)) 
+    event = dependencies
+
+    if direction isa EveryDirection || direction isa HorizontalDirection
+        @assert dim == 2 || Nq1 == Nq2
+        filtermatrix = filter.filter_matrices[1]
+        event = kernel_apply_mp_filter!(device, (Nq1, Nq2, Nq3))(
+            Val(nreduce),
+            Val(dim),
+            Val(N),
+            Val(vars(Q)),
+            Val(isnothing(state_auxiliary) ? nothing : vars(state_auxiliary)),
+            HorizontalDirection(),
+            Q.data,
+            isnothing(state_auxiliary) ? nothing : state_auxiliary.data,
+            target,
+            filtermatrix,
+            grid.vgeo,
+            ndrange = (nrealelem * Nq1, Nq2, Nq3),
+            dependencies = event,
+        )
+    end
+    if direction isa EveryDirection || direction isa VerticalDirection
+        filtermatrix = filter.filter_matrices[end]
+        event = kernel_apply_mp_filter!(device, (Nq1, Nq2, Nq3))(
+            Val(nreduce),
+            Val(dim),
+            Val(N),
+            Val(vars(Q)),
+            Val(isnothing(state_auxiliary) ? nothing : vars(state_auxiliary)),
+            VerticalDirection(),
+            Q.data,
+            isnothing(state_auxiliary) ? nothing : state_auxiliary.data,
+            target,
+            filtermatrix,
+            grid.vgeo,
+            ndrange = (nrealelem * Nq1, Nq2, Nq3),
+            dependencies = event,
+        )
+    end
+    return event
+end
+
+
+const _M = Grids._M
+# mp for masspreserving
+"""
+    kernel_apply_mp_filter!(::Val{dim}, ::Val{N}, direction,
+                         Q, state_auxiliary, target, filtermatrix
+                        ) where {dim, N}
+Computational kernel: Applies the `filtermatrix` to `Q` given a
+custom target `target`.
+The `direction` argument is used to control if the filter is applied in the
+""" 
+@kernel function kernel_apply_mp_filter!(
+    ::Val{nreduce},
+    ::Val{dim},
+    ::Val{N},
+    ::Val{vars_Q},
+    ::Val{vars_state_auxiliary},
+    direction,
+    Q,
+    state_auxiliary,
+    target::AbstractFilterTarget,
+    filtermatrix,
+    vgeo,
+) where {nreduce, dim, N, vars_Q, vars_state_auxiliary}
+    @uniform begin
+        FT = eltype(Q)
+
+        Nqs = N .+ 1
+        Nq1 = Nqs[1]
+        Nq2 = Nqs[2]
+        Nq3 = dim == 2 ? 1 : Nqs[dim]
+
+        if direction isa EveryDirection
+            filterinξ1 = filterinξ2 = true
+            filterinξ3 = dim == 2 ? false : true
+        elseif direction isa HorizontalDirection
+            filterinξ1 = true
+            filterinξ2 = dim == 2 ? false : true
+            filterinξ3 = false
+        elseif direction isa VerticalDirection
+            filterinξ1 = false
+            filterinξ2 = dim == 2 ? true : false
+            filterinξ3 = dim == 2 ? false : true
+        end
+
+        nstates = varsize(vars_Q)
+        nfilterstates = number_state_filtered(target, FT)
+        nfilteraux =
+            isnothing(state_auxiliary) ? 0 : varsize(vars_state_auxiliary)
+
+        # ugly workaround around problems with @private
+        # hopefully will be soon fixed in KA
+        l_Q2 = MVector{nstates, FT}(undef)
+        l_Qfiltered2 = MVector{nfilterstates, FT}(undef)
+    end
+
+    s_Q = @localmem FT (Nq1, Nq2, Nq3, nfilterstates) # element local 
+    s_MQᴮ = @localmem FT (Nq1 * Nq2 * Nq3, nstates) # before applying filter
+    s_MQᴬ = @localmem FT (Nq1 * Nq2 * Nq3, nstates) # after applying filter
+    s_M  = @localmem FT (Nq1 * Nq2 * Nq3) # local mass matrix
+
+    l_Q = @private FT (nstates,)
+    l_Qfiltered = @private FT (nfilterstates,) # scratch space for storing mat mul
+    l_aux = @private FT (nfilteraux,)
+
+    e = @index(Group, Linear)
+    i, j, k = @index(Local, NTuple)
+    ijk = @index(Local, Linear)
+
+    @inbounds begin
+
+        @unroll for s in 1:nstates
+            l_Q[s] = Q[ijk, s, e]
+        end
+
+        @unroll for s in 1:nfilteraux
+            l_aux[s] = state_auxiliary[ijk, s, e]
+        end
+
+         # Load mass weighted quantities to shared memory
+         s_M[ijk] = vgeo[ijk, _M, e]
+         @unroll for s in 1:nstates
+             s_MQᴮ[ijk, s] = s_M[ijk] * l_Q[s]
+         end
+
+        fill!(l_Qfiltered2, -zero(FT))
+
+        compute_filter_argument!(
+            target,
+            Vars{vars_state_filtered(target, FT)}(l_Qfiltered2),
+            Vars{vars_Q}(l_Q[:]),
+            Vars{vars_state_auxiliary}(l_aux[:]),
+        )
+
+        @unroll for fs in 1:nfilterstates
+            l_Qfiltered[fs] = zero(FT)
+        end
+
+        @unroll for fs in 1:nfilterstates
+            s_Q[i, j, k, fs] = l_Qfiltered2[fs]
+        end
+
+        if filterinξ1
+            @synchronize
+            @unroll for n in 1:Nq1
+                @unroll for fs in 1:nfilterstates
+                    l_Qfiltered[fs] += filtermatrix[i, n] * s_Q[n, j, k, fs]
+                end
+            end
+
+            if filterinξ2 || filterinξ3
+                @synchronize
+                @unroll for fs in 1:nfilterstates
+                    s_Q[i, j, k, fs] = l_Qfiltered[fs]
+                    l_Qfiltered[fs] = zero(FT)
+                end
+            end
+        end
+
+        if filterinξ2
+            @synchronize
+            @unroll for n in 1:Nq2
+                @unroll for fs in 1:nfilterstates
+                    l_Qfiltered[fs] += filtermatrix[j, n] * s_Q[i, n, k, fs]
+                end
+            end
+
+            if filterinξ3
+                @synchronize
+                @unroll for fs in 1:nfilterstates
+                    s_Q[i, j, k, fs] = l_Qfiltered[fs]
+                    l_Qfiltered[fs] = zero(FT)
+                end
+            end
+        end
+
+        if filterinξ3
+            @synchronize
+            @unroll for n in 1:Nq3
+                @unroll for fs in 1:nfilterstates
+                    l_Qfiltered[fs] += filtermatrix[k, n] * s_Q[i, j, n, fs]
+                end
+            end
+        end
+
+        @unroll for s in 1:nstates
+            l_Q2[s] = l_Q[s]
+        end
+
+        compute_filter_result!(
+            target,
+            Vars{vars_Q}(l_Q2),
+            Vars{vars_state_filtered(target, FT)}(l_Qfiltered[:]),
+            Vars{vars_state_auxiliary}(l_aux[:]),
+        )
+        # Store result
+        @unroll for s in 1:nstates
+            l_Q[s] = l_Q2[s]
+            s_MQᴬ[ijk, s] = s_M[ijk] * l_Q[s]
+        end
+
+        @synchronize
+        @unroll for n in 11:-1:1
+            if nreduce ≥ (1 << n)     
+                ijkshift = ijk + (1 << (n - 1))
+                if ijk ≤ (1 << (n - 1)) && ijkshift ≤ Nq1 * Nq2 * Nq3
+                    s_M[ijk] += s_M[ijkshift]
+                    @unroll for s in 1:nstates
+                        s_MQᴮ[ijk, s] += s_MQᴮ[ijkshift, s]
+                        s_MQᴬ[ijk, s] += s_MQᴬ[ijkshift, s]
+                    end
+                end
+                @synchronize
+            end
+        end
+
+        @synchronize
+        M⁻¹ = FT(1) / s_M[1]
+        @unroll for s in 1:nstates
+            Q[ijk, s, e] = l_Q[s] + M⁻¹ * (s_MQᴮ[1, s] - s_MQᴬ[1, s])
+        end
+
+        @synchronize
+    end
+
+end

--- a/experiments/SlabOcean/numerics/numerical_interface_fluxes.jl
+++ b/experiments/SlabOcean/numerics/numerical_interface_fluxes.jl
@@ -1,0 +1,436 @@
+using ClimateMachine.NumericalFluxes
+
+import ClimateMachine.NumericalFluxes: numerical_flux_first_order!
+
+struct RefanovFlux <: NumericalFluxFirstOrder end 
+
+Base.@kwdef struct RoesanovFlux{S,T} <: NumericalFluxFirstOrder
+    ω_roe::S = 1.0
+    ω_rusanov::T = 1.0
+end
+
+roe_average(ρ⁻, ρ⁺, var⁻, var⁺) =
+    (sqrt(ρ⁻) * var⁻ + sqrt(ρ⁺) * var⁺) / (sqrt(ρ⁻) + sqrt(ρ⁺))
+
+function numerical_flux_first_order!(
+    ::RoeNumericalFlux,
+    model::ModelSetup,
+    fluxᵀn::Vars{S},
+    n⁻::SVector,
+    state⁻::Vars{S},
+    aux⁻::Vars{A},
+    state⁺::Vars{S},
+    aux⁺::Vars{A},
+    t,
+    direction,
+) where {S, A}
+    numerical_flux_first_order!(
+        CentralNumericalFluxFirstOrder(),
+        model,
+        fluxᵀn,
+        n⁻,
+        state⁻,
+        aux⁻,
+        state⁺,
+        aux⁺,
+        t,
+        direction,
+    )
+    eos = model.physics.eos
+    parameters = model.physics.parameters 
+
+    # - states
+    ρ⁻ = state⁻.ρ
+    ρu⁻ = state⁻.ρu
+    ρθ⁻ = state⁻.ρθ
+
+    # constructed states
+    u⁻ = ρu⁻ / ρ⁻
+    θ⁻ = ρθ⁻ / ρ⁻
+
+    # in general thermodynamics
+    p⁻ = calc_pressure(eos, state⁻, aux⁻, parameters)
+    c⁻ = calc_sound_speed(eos, state⁻, aux⁻, parameters)
+
+    # + states
+    ρ⁺ = state⁺.ρ
+    ρu⁺ = state⁺.ρu
+    ρθ⁺ = state⁺.ρθ
+
+    # constructed states
+    u⁺ = ρu⁺ / ρ⁺
+    θ⁺ = ρθ⁺ / ρ⁺
+
+    # in general thermodynamics
+    p⁺ = calc_pressure(eos, state⁺, aux⁺, parameters)
+    c⁺ = calc_sound_speed(eos, state⁺, aux⁺, parameters)
+
+    # construct roe averges
+    ρ = sqrt(ρ⁻ * ρ⁺)
+    u = roe_average(ρ⁻, ρ⁺, u⁻, u⁺)
+    θ = roe_average(ρ⁻, ρ⁺, θ⁻, θ⁺)
+    c = roe_average(ρ⁻, ρ⁺, c⁻, c⁺)
+
+    # construct normal velocity
+    uₙ = u' * n⁻
+
+    # differences
+    Δρ = ρ⁺ - ρ⁻
+    Δp = p⁺ - p⁻
+    Δu = u⁺ - u⁻
+    Δρθ = ρθ⁺ - ρθ⁻
+    Δuₙ = Δu' * n⁻
+
+    # constructed values
+    c⁻² = 1 / c^2
+    w1 = abs(uₙ - c) * (Δp - ρ * c * Δuₙ) * 0.5 * c⁻²
+    w2 = abs(uₙ + c) * (Δp + ρ * c * Δuₙ) * 0.5 * c⁻²
+    w3 = abs(uₙ) * (Δρ - Δp * c⁻²)
+    w4 = abs(uₙ) * ρ
+    w5 = abs(uₙ) * (Δρθ - θ * Δp * c⁻²)
+
+    # fluxes!!!
+    fluxᵀn.ρ -= (w1 + w2 + w3) * 0.5
+    fluxᵀn.ρu -=
+        (
+            w1 * (u - c * n⁻) +
+            w2 * (u + c * n⁻) +
+            w3 * u +
+            w4 * (Δu - Δuₙ * n⁻)
+        ) * 0.5
+    fluxᵀn.ρθ -= ((w1 + w2) * θ + w5) * 0.5
+
+    return nothing
+end
+
+function numerical_flux_first_order!(
+    ::RoeNumericalFlux,
+    balance_law::DryAtmosModel,
+    fluxᵀn::Vars{S},
+    normal_vector::SVector,
+    state_prognostic⁻::Vars{S},
+    state_auxiliary⁻::Vars{A},
+    state_prognostic⁺::Vars{S},
+    state_auxiliary⁺::Vars{A},
+    t,
+    direction,
+) where {S, A}
+
+    numerical_flux_first_order!(
+        CentralNumericalFluxFirstOrder(),
+        balance_law,
+        fluxᵀn,
+        normal_vector,
+        state_prognostic⁻,
+        state_auxiliary⁻,
+        state_prognostic⁺,
+        state_auxiliary⁺,
+        t,
+        direction,
+    )
+    eos = balance_law.physics.eos
+    parameters = balance_law.physics.parameters
+
+    cv_d = parameters.cv_d
+    T_0  = parameters.T_0
+
+    Φ = state_auxiliary⁻.Φ #Φ⁻ and Φ⁺ have the same value
+    ρ⁻ = state_prognostic⁻.ρ
+    ρu⁻ = state_prognostic⁻.ρu
+    u⁻ = ρu⁻ / ρ⁻
+
+    p⁻ = calc_pressure(eos, state_prognostic⁻, state_auxiliary⁻, parameters)
+    c⁻ = calc_sound_speed(eos, state_prognostic⁻, state_auxiliary⁻, parameters)
+    h⁻ = calc_total_specific_enthalpy(eos, state_prognostic⁻, state_auxiliary⁻, parameters)
+
+    ρ⁺ = state_prognostic⁺.ρ
+    ρu⁺ = state_prognostic⁺.ρu
+    u⁺ = ρu⁺ / ρ⁺
+
+    p⁺ = calc_pressure(eos, state_prognostic⁺, state_auxiliary⁺, parameters)
+    c⁺ = calc_sound_speed(eos, state_prognostic⁺, state_auxiliary⁺, parameters)
+    h⁺ = calc_total_specific_enthalpy(eos, state_prognostic⁺, state_auxiliary⁺, parameters)
+
+    ρ̃ = sqrt(ρ⁻ * ρ⁺)
+    ũ = roe_average(ρ⁻, ρ⁺, u⁻, u⁺)
+    h̃ = roe_average(ρ⁻, ρ⁺, h⁻, h⁺)
+    c̃ = sqrt(roe_average(ρ⁻, ρ⁺, c⁻^2, c⁺^2))
+
+    ũᵀn = ũ' * normal_vector
+
+    Δρ = ρ⁺ - ρ⁻
+    Δp = p⁺ - p⁻
+    Δu = u⁺ - u⁻
+    Δuᵀn = Δu' * normal_vector
+
+    w1 = abs(ũᵀn - c̃) * (Δp - ρ̃ * c̃ * Δuᵀn) / (2 * c̃^2)
+    w2 = abs(ũᵀn + c̃) * (Δp + ρ̃ * c̃ * Δuᵀn) / (2 * c̃^2)
+    w3 = abs(ũᵀn) * (Δρ - Δp / c̃^2)
+    w4 = abs(ũᵀn) * ρ̃
+
+    fluxᵀn.ρ -= (w1 + w2 + w3) / 2
+    fluxᵀn.ρu -=
+        (
+            w1 * (ũ - c̃ * normal_vector) +
+            w2 * (ũ + c̃ * normal_vector) +
+            w3 * ũ +
+            w4 * (Δu - Δuᵀn * normal_vector)
+        ) / 2
+    fluxᵀn.ρe -=
+        (
+            w1 * (h̃ - c̃ * ũᵀn) +
+            w2 * (h̃ + c̃ * ũᵀn) +
+            w3 * (ũ' * ũ / 2 + Φ - T_0 * cv_d) +
+            w4 * (ũ' * Δu - ũᵀn * Δuᵀn)
+        ) / 2
+end
+
+function numerical_flux_first_order!(
+    ϕ::RoesanovFlux,
+    model::ModelSetup,
+    fluxᵀn::Vars{S},
+    n⁻::SVector,
+    state⁻::Vars{S},
+    aux⁻::Vars{A},
+    state⁺::Vars{S},
+    aux⁺::Vars{A},
+    t,
+    direction,
+) where {S, A}
+    numerical_flux_first_order!(
+        CentralNumericalFluxFirstOrder(),
+        model,
+        fluxᵀn,
+        n⁻,
+        state⁻,
+        aux⁻,
+        state⁺,
+        aux⁺,
+        t,
+        direction,
+    )
+    eos = model.physics.eos
+
+    # - states
+    ρ⁻ = state⁻.ρ
+    ρu⁻ = state⁻.ρu
+    ρθ⁻ = state⁻.ρθ
+
+    # constructed states
+    u⁻ = ρu⁻ / ρ⁻
+    θ⁻ = ρθ⁻ / ρ⁻
+
+    # in general thermodynamics
+    p⁻ = calc_pressure(eos, state⁻, aux⁻, parameters)
+    c⁻ = calc_sound_speed(eos, state⁻, aux⁻, parameters)
+
+    # + states
+    ρ⁺ = state⁺.ρ
+    ρu⁺ = state⁺.ρu
+    ρθ⁺ = state⁺.ρθ
+
+    # constructed states
+    u⁺ = ρu⁺ / ρ⁺
+    θ⁺ = ρθ⁺ / ρ⁺
+
+    # in general thermodynamics
+    p⁺ = calc_pressure(eos, state⁺, aux⁺, parameters)
+    c⁺ = calc_sound_speed(eos, state⁺, aux⁺, parameters)
+
+    # construct roe averges
+    ρ = sqrt(ρ⁻ * ρ⁺)
+    u = roe_average(ρ⁻, ρ⁺, u⁻, u⁺)
+    θ = roe_average(ρ⁻, ρ⁺, θ⁻, θ⁺)
+    c = roe_average(ρ⁻, ρ⁺, c⁻, c⁺)
+
+    # construct normal velocity
+    uₙ = u' * n⁻
+
+    # differences
+    Δρ = ρ⁺ - ρ⁻
+    Δp = p⁺ - p⁻
+    Δu = u⁺ - u⁻
+    Δρθ = ρθ⁺ - ρθ⁻
+    Δuₙ = Δu' * n⁻
+
+    # constructed values
+    c⁻² = 1 / c^2
+    w1 = abs(uₙ - c) * (Δp - ρ * c * Δuₙ) * 0.5 * c⁻²
+    w2 = abs(uₙ + c) * (Δp + ρ * c * Δuₙ) * 0.5 * c⁻²
+    w3 = abs(uₙ) * (Δρ - Δp * c⁻²)
+    w4 = abs(uₙ) * ρ
+    w5 = abs(uₙ) * (Δρθ - θ * Δp * c⁻²)
+
+    # fluxes!!!
+    ω1 = ϕ.ω_roe
+    fluxᵀn.ρ -= (w1 + w2 + w3) * 0.5 * ω1
+    fluxᵀn.ρu -=
+        (
+            w1 * (u - c * n⁻) +
+            w2 * (u + c * n⁻) +
+            w3 * u +
+            w4 * (Δu - Δuₙ * n⁻)
+        ) * 0.5 * ω1
+    fluxᵀn.ρθ -= ((w1 + w2) * θ + w5) * 0.5 * ω1
+    
+    ω2 = ϕ.ω_rusanov
+    max_wavespeed = max(c⁻, c⁺)
+    Δρu = ρu⁺ - ρu⁻
+    fluxᵀn.ρu -=
+        (
+            max_wavespeed * Δρu
+        ) * 0.5 * ω2
+
+    return nothing
+end
+
+function numerical_flux_first_order!(
+    ::LMARSNumericalFlux,
+    balance_law::DryAtmosModel,
+    fluxᵀn::Vars{S},
+    normal_vector::SVector,
+    state_prognostic⁻::Vars{S},
+    state_auxiliary⁻::Vars{A},
+    state_prognostic⁺::Vars{S},
+    state_auxiliary⁺::Vars{A},
+    t,
+    direction,
+) where {S, A}
+    FT = eltype(fluxᵀn)
+    eos = balance_law.physics.eos
+    parameters = balance_law.physics.parameters
+
+    ρ⁻ = state_prognostic⁻.ρ
+    ρu⁻ = state_prognostic⁻.ρu
+    u⁻ = ρu⁻ / ρ⁻
+    uᵀn⁻ = u⁻' * normal_vector
+
+    p⁻ = calc_pressure(eos, state_prognostic⁻, state_auxiliary⁻, parameters)
+    # if the reference state is removed in the momentum equations (meaning p-p_ref is used for pressure gradient force) then we should remove the reference pressure
+    #     p⁻ -= state_auxiliary⁻.ref_state.p
+    # end
+    c⁻ = calc_sound_speed(eos, state_prognostic⁻, state_auxiliary⁻, parameters)
+    h⁻ = calc_total_specific_enthalpy(eos, state_prognostic⁻, state_auxiliary⁻, parameters)
+
+    ρ⁺ = state_prognostic⁺.ρ
+    ρu⁺ = state_prognostic⁺.ρu
+    u⁺ = ρu⁺ / ρ⁺
+    uᵀn⁺ = u⁺' * normal_vector
+
+    p⁺ = calc_pressure(eos, state_prognostic⁺, state_auxiliary⁺, parameters)
+    # if the reference state is removed in the momentum equations (meaning p-p_ref is used for pressure gradient force) then we should remove the reference pressure
+    #     p⁺ -= state_auxiliary⁺.ref_state.p
+    # end
+    # c⁺ = calc_sound_speed(eos, state_prognostic⁺, state_auxiliary⁺, parameters)
+    h⁺ = calc_total_specific_enthalpy(eos, state_prognostic⁺, state_auxiliary⁺, parameters)
+
+    # Eqn (49), (50), β the tuning parameter
+    β = FT(1)
+    u_half = 1 / 2 * (uᵀn⁺ + uᵀn⁻) - β * 1 / (ρ⁻ + ρ⁺) / c⁻ * (p⁺ - p⁻)
+    p_half = 1 / 2 * (p⁺ + p⁻) - β * ((ρ⁻ + ρ⁺) * c⁻) / 4 * (uᵀn⁺ - uᵀn⁻)
+
+    # Eqn (46), (47)
+    ρ_b = u_half > FT(0) ? ρ⁻ : ρ⁺
+    ρu_b = u_half > FT(0) ? ρu⁻ : ρu⁺
+    ρh_b = u_half > FT(0) ? ρ⁻ * h⁻ : ρ⁺ * h⁺
+
+    # Update fluxes Eqn (18)
+    fluxᵀn.ρ = ρ_b * u_half
+    fluxᵀn.ρu = ρu_b * u_half .+ p_half * normal_vector
+    fluxᵀn.ρe = ρh_b * u_half
+
+    # Update fluxes for moisture
+    ρq⁻ = state_prognostic⁻.ρq
+    q⁻ = ρq⁻ / ρ⁻
+    ρq⁺ = state_prognostic⁺.ρq
+    q⁺ = ρq⁺ / ρ⁺
+    ρq_b = u_half > FT(0) ? ρq⁻ : ρq⁺
+    fluxᵀn.ρq = ρq_b * u_half
+
+    # if !(tracer_model(balance_law) isa NoTracers)
+    #     ρχ⁻ = state_prognostic⁻.tracers.ρχ
+    #     χ⁻ = ρχ⁻ / ρ⁻
+    #     ρχ⁺ = state_prognostic⁺.tracers.ρχ
+    #     χ⁺ = ρχ⁺ / ρ⁺
+    #     ρχ_b = u_half > FT(0) ? ρχ⁻ : ρχ⁺
+    #     fluxᵀn.tracers.ρχ = ρχ_b * u_half
+    # end
+end
+
+numerical_flux_first_order!(::Nothing, ::DryAtmosModel, _...) = nothing
+numerical_flux_second_order!(::Nothing, ::DryAtmosModel, _...) = nothing
+numerical_boundary_flux_second_order!(::Nothing, a, ::DryAtmosModel, _...) = nothing
+
+function wavespeed(
+    model::DryAtmosModel,
+    n⁻,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+    direction,
+)
+    eos = model.physics.eos
+    parameters = model.physics.parameters
+    ρ = state.ρ
+    ρu = state.ρu
+
+    u = ρu / ρ
+    u_norm = abs(dot(n⁻, u))
+    return u_norm + calc_sound_speed(eos, state, aux, parameters)
+end
+
+function numerical_flux_first_order!(
+    ::RefanovFlux,
+    model::DryAtmosModel,
+    fluxᵀn::Vars{S},
+    normal_vector::SVector,
+    state⁻::Vars{S},
+    aux⁻::Vars{A},
+    state⁺::Vars{S},
+    aux⁺::Vars{A},
+    t,
+    direction,
+) where {S, A}
+
+    numerical_flux_first_order!(
+        CentralNumericalFluxFirstOrder(),
+        model,
+        fluxᵀn,
+        normal_vector,
+        state⁻,
+        aux⁻,
+        state⁺,
+        aux⁺,
+        t,
+        direction,
+    )
+
+    eos = model.physics.eos
+    parameters = model.physics.parameters
+    
+    c⁻ = calc_ref_sound_speed(eos, state⁻, aux⁻, parameters)
+    c⁺ = calc_ref_sound_speed(eos, state⁺, aux⁺, parameters)
+    c = max(c⁻, c⁺)
+
+    # - states
+    ρ⁻ = state⁻.ρ
+    ρu⁻ = state⁻.ρu
+    ρe⁻ = state⁻.ρe
+    ρq⁻ = state⁻.ρq
+
+    # + states
+    ρ⁺ = state⁺.ρ
+    ρu⁺ = state⁺.ρu
+    ρe⁺ = state⁺.ρe
+    ρq⁺ = state⁺.ρq
+
+    Δρ = ρ⁺ - ρ⁻
+    Δρu = ρu⁺ - ρu⁻
+    Δρe = ρe⁺ - ρe⁻
+    Δρq = ρq⁺ - ρq⁻
+
+    fluxᵀn.ρ  -= c * Δρ  * 0.5
+    fluxᵀn.ρu -= c * Δρu * 0.5
+    fluxᵀn.ρe -= c * Δρe * 0.5
+    #fluxᵀn.ρq -= c * Δρq * 0.5
+end

--- a/experiments/SlabOcean/numerics/numerical_volume_fluxes.jl
+++ b/experiments/SlabOcean/numerics/numerical_volume_fluxes.jl
@@ -1,0 +1,253 @@
+using ClimateMachine.DGMethods.NumericalFluxes: NumericalFluxFirstOrder
+import ClimateMachine.DGMethods.NumericalFluxes:
+    numerical_volume_conservative_flux_first_order!,
+    numerical_volume_fluctuation_flux_first_order!,
+    ave,
+    numerical_flux_first_order!,
+    numerical_flux_second_order!,
+    numerical_boundary_flux_second_order!
+import ClimateMachine.BalanceLaws:
+    wavespeed
+
+struct CentralVolumeFlux <: NumericalFluxFirstOrder end
+struct KGVolumeFlux <: NumericalFluxFirstOrder end
+struct LinearKGVolumeFlux <: NumericalFluxFirstOrder end
+struct VeryLinearKGVolumeFlux <: NumericalFluxFirstOrder end
+
+function numerical_volume_fluctuation_flux_first_order!(
+    ::NumericalFluxFirstOrder,
+    model::DryAtmosModel,
+    D::Grad,
+    state_1::Vars,
+    aux_1::Vars,
+    state_2::Vars,
+    aux_2::Vars,
+)
+
+    sources = model.physics.sources
+
+    ntuple(Val(length(sources))) do s
+        Base.@_inline_meta
+        calc_fluctuation_component!(D, sources[s], state_1, state_2, aux_1, aux_2)
+    end
+    #=
+    if fluctuation_gravity
+        ρ_1, ρ_2 = state_1.ρ, state_2.ρ
+        Φ_1, Φ_2 = aux_1.Φ, aux_2.Φ
+
+        α = ave(ρ_1, ρ_2) * 0.5
+
+        D.ρu -= α * (Φ_1 - Φ_2) * I
+    end
+    =#
+end
+
+function numerical_volume_conservative_flux_first_order!(
+    ::CentralVolumeFlux,
+    m::DryAtmosModel,
+    F::Grad,
+    state_1::Vars,
+    aux_1::Vars,
+    state_2::Vars,
+    aux_2::Vars,
+)
+    FT = eltype(F)
+    F_1 = similar(F)
+    flux_first_order!(m, F_1, state_1, aux_1, FT(0), EveryDirection())
+
+    F_2 = similar(F)
+    flux_first_order!(m, F_2, state_2, aux_2, FT(0), EveryDirection())
+
+    parent(F) .= (parent(F_1) .+ parent(F_2)) ./ 2
+end
+
+function numerical_volume_conservative_flux_first_order!(
+    ::KGVolumeFlux,
+    model::DryAtmosModel,
+    F::Grad,
+    state_1::Vars,
+    aux_1::Vars,
+    state_2::Vars,
+    aux_2::Vars,
+)
+    eos = model.physics.eos
+    parameters = model.physics.parameters
+
+    ρ_1 = state_1.ρ
+    ρu_1 = state_1.ρu
+    ρe_1 = state_1.ρe
+    ρq_1 = state_1.ρq
+    u_1 = ρu_1 / ρ_1
+    e_1 = ρe_1 / ρ_1
+    q_1 = ρq_1 / ρ_1
+    p_1 = calc_pressure(eos, state_1, aux_1, parameters)
+
+    ρ_2 = state_2.ρ
+    ρu_2 = state_2.ρu
+    ρe_2 = state_2.ρe
+    ρq_2 = state_2.ρq
+    u_2 = ρu_2 / ρ_2
+    e_2 = ρe_2 / ρ_2
+    q_2 = ρq_2 / ρ_2
+    p_2 = calc_pressure(eos, state_2, aux_2, parameters)
+
+    ρ_avg = ave(ρ_1, ρ_2)
+    u_avg = ave(u_1, u_2)
+    e_avg = ave(e_1, e_2)
+    q_avg = ave(q_1, q_2)
+    p_avg = ave(p_1, p_2)
+
+    F.ρ  = ρ_avg * u_avg
+    F.ρu = p_avg * I + ρ_avg * u_avg .* u_avg'
+    F.ρe = ρ_avg * u_avg * e_avg + p_avg * u_avg
+    F.ρq = ρ_avg * u_avg * q_avg
+end
+
+function numerical_volume_conservative_flux_first_order!(
+    ::LinearKGVolumeFlux,
+    model::DryAtmosModel,
+    F::Grad,
+    state_1::Vars,
+    aux_1::Vars,
+    state_2::Vars,
+    aux_2::Vars,
+)
+    eos = model.physics.eos
+    parameters = model.physics.parameters
+    
+    ρu_1 = state_1.ρu
+    ρuᵣ = ρu_1 * 0
+    p_1 = calc_linear_pressure(eos, state_1, aux_1, parameters)
+
+    # grab reference state
+    ρᵣ_1 = aux_1.ref_state.ρ
+    pᵣ_1 = aux_1.ref_state.p
+    ρeᵣ_1 = aux_1.ref_state.ρe
+
+    # only ρu fluctuates in the non-pressure terms
+    u_1 = ρu_1 / ρᵣ_1 
+    eᵣ_1 = ρeᵣ_1 / ρᵣ_1
+    ρu_2 = state_2.ρu
+
+    ρuᵣ = ρu_2 * 0
+    p_2 = calc_linear_pressure(eos, state_2, aux_2, parameters)
+
+    # grab reference state
+    ρᵣ_2 = aux_2.ref_state.ρ
+    pᵣ_2 = aux_2.ref_state.p
+    ρeᵣ_2 = aux_2.ref_state.ρe
+
+    # only ρu fluctuates in the non-pressure terms
+    u_2 = ρu_2 / ρᵣ_2 
+    eᵣ_2 = ρeᵣ_2 / ρᵣ_2
+
+    # construct averages
+    ρᵣ_avg = ave(ρᵣ_1, ρᵣ_2)
+    eᵣ_avg = ave(eᵣ_1, eᵣ_2)
+    pᵣ_avg = ave(pᵣ_1, pᵣ_2)
+
+    u_avg = ave(u_1, u_2)
+    p_avg = ave(p_1, p_2)
+
+    F.ρ = ρᵣ_avg * u_avg 
+    F.ρu = p_avg * I + ρuᵣ .* ρuᵣ' # the latter term is needed to determine size of I
+    F.ρe = (ρᵣ_avg * eᵣ_avg + pᵣ_avg) * u_avg
+end
+
+# TODO: UPDATE EOS 
+#=
+function calc_linear_pressure(eos::DryIdealGas{(:ρ, :ρu, :ρe)}, state, aux, params)
+    ρ  = state.ρ
+    ρe = state.ρe
+    Φ  = aux.Φ
+    γ  = calc_γ(eos, state, params)
+    # full : (ρe - dot(ρu, ρu) / 2ρ - ρ * Φ)
+
+    return (γ - 1) * (ρe - ρ * Φ - dot(ρu, ρuᵣ) / ρᵣ + ρ * dot(ρuᵣ, ρuᵣ) / (2 * ρᵣ^2) ) 
+end
+=#
+function numerical_volume_conservative_flux_first_order!(
+    ::VeryLinearKGVolumeFlux,
+    model::DryAtmosModel,
+    F::Grad,
+    state_1::Vars,
+    aux_1::Vars,
+    state_2::Vars,
+    aux_2::Vars,
+)
+    eos = model.physics.eos
+    parameters = model.physics.parameters
+    
+    ## State 1 Stuff 
+    # unpack the perturbation state
+    ρ_1 = state_1.ρ
+    ρu_1 = state_1.ρu
+    ρe_1 = state_1.ρe
+    ρq_1 = state_1.ρq
+
+    # grab reference state
+    ρᵣ_1  = aux_1.ref_state.ρ
+    ρuᵣ_1 = aux_1.ref_state.ρu
+    ρeᵣ_1 = aux_1.ref_state.ρe
+    ρqᵣ_1 = aux_1.ref_state.ρq
+    pᵣ_1  = aux_1.ref_state.p
+
+    # calculate pressure perturbation
+    p_1 = calc_very_linear_pressure(eos, state_1, aux_1, parameters)
+
+    # calculate u_1, q_1, e_1, and reference states
+    u_1  = ρu_1 / ρᵣ_1 - ρ_1 * ρuᵣ_1 / (ρᵣ_1^2)
+    q_1  = ρq_1 / ρᵣ_1 - ρ_1 * ρqᵣ_1 / (ρᵣ_1^2)
+    e_1  = ρe_1 / ρᵣ_1 - ρ_1 * ρeᵣ_1 / (ρᵣ_1^2)
+
+    uᵣ_1 = ρuᵣ_1 / ρᵣ_1
+    qᵣ_1 = ρqᵣ_1 / ρᵣ_1
+    eᵣ_1 = ρeᵣ_1 / ρᵣ_1
+
+    ## State 2 Stuff 
+    # unpack the state perubation
+    ρ_2 = state_2.ρ
+    ρu_2 = state_2.ρu
+    ρe_2 = state_2.ρe
+    ρq_2 = state_2.ρq
+
+    # grab reference state
+    ρᵣ_2  = aux_2.ref_state.ρ
+    ρuᵣ_2 = aux_2.ref_state.ρu
+    ρeᵣ_2 = aux_2.ref_state.ρe
+    ρqᵣ_2 = aux_2.ref_state.ρq
+    pᵣ_2  = aux_2.ref_state.p
+
+    # calculate pressure perturbation
+    p_2 = calc_very_linear_pressure(eos, state_2, aux_2, parameters)
+
+    # calculate u_2, q_2, e_2, and reference states
+    u_2  = ρu_2 / ρᵣ_2 - ρ_2 * ρuᵣ_2 / (ρᵣ_2^2)
+    q_2  = ρq_2 / ρᵣ_2 - ρ_2 * ρqᵣ_2 / (ρᵣ_2^2)
+    e_2  = ρe_2 / ρᵣ_2 - ρ_2 * ρeᵣ_2 / (ρᵣ_2^2)
+
+    uᵣ_2 = ρuᵣ_2 / ρᵣ_2
+    qᵣ_2 = ρqᵣ_2 / ρᵣ_2
+    eᵣ_2 = ρeᵣ_2 / ρᵣ_2
+
+    # construct averages for perturbation variables
+    ρ_avg = ave(ρ_1, ρ_2)
+    u_avg = ave(u_1, u_2)
+    e_avg = ave(e_1, e_2)
+    q_avg = ave(q_1, q_2)
+    p_avg = ave(p_1, p_2)
+
+    # construct averages for reference variables
+    ρᵣ_avg = ave(ρᵣ_1, ρᵣ_2)
+    uᵣ_avg = ave(uᵣ_1, uᵣ_2)
+    eᵣ_avg = ave(eᵣ_1, eᵣ_2)
+    qᵣ_avg = ave(qᵣ_1, qᵣ_2)
+    pᵣ_avg = ave(pᵣ_1, pᵣ_2)
+
+    F.ρ   = ρᵣ_avg * u_avg + ρ_avg * uᵣ_avg
+    F.ρu  = p_avg * I + ρᵣ_avg .* (uᵣ_avg .* u_avg' + u_avg .* uᵣ_avg') 
+    F.ρu += (ρ_avg .* uᵣ_avg) .* uᵣ_avg' 
+    F.ρe  = (ρᵣ_avg * eᵣ_avg + pᵣ_avg) * u_avg
+    F.ρe += (ρᵣ_avg * e_avg + ρ_avg * eᵣ_avg + p_avg) * uᵣ_avg
+    F.ρq  = ρᵣ_avg * qᵣ_avg * u_avg + (ρᵣ_avg * q_avg + ρ_avg * qᵣ_avg)* uᵣ_avg
+end

--- a/experiments/SlabOcean/numerics/timestepper_abstractions.jl
+++ b/experiments/SlabOcean/numerics/timestepper_abstractions.jl
@@ -1,0 +1,119 @@
+abstract type AbstractRate end
+
+# TODO: Add more methods here such as MultiRate, Explicit [can't reuse word]
+Base.@kwdef struct IMEX{ℱ}
+    method::ℱ
+end
+
+function IMEX()
+    return IMEX(ARK2GiraldoKellyConstantinescu)
+end
+
+Base.@kwdef struct Explicit{ℳ, ℛ} <: AbstractRate
+    model::ℳ
+    rate::ℛ = 1
+end
+
+function Explicit(model::BalanceLaw; rate = 1) 
+    return Explicit(model = model, rate = rate)
+end
+
+function Explicit(model::SpaceDiscretization; rate = 1) 
+    return Explicit(model = model, rate = rate)
+end
+
+# perhaps "solver_method" instead of "method"?
+Base.@kwdef struct Implicit{ℳ, ℛ, 𝒜} <: AbstractRate
+    model::ℳ
+    rate::ℛ = 1
+    method::𝒜 = LinearBackwardEulerSolver(ManyColumnLU(); isadjustable = false)
+end
+
+function Implicit(model::BalanceLaw; rate = 1, adjustable = false, method = LinearBackwardEulerSolver(ManyColumnLU(), isadjustable = false)) 
+    return Implicit(model = model, rate = rate, method = method)
+end
+
+function Implicit(model::SpaceDiscretization; rate = 1, adjustable = false, method = LinearBackwardEulerSolver(ManyColumnLU(), isadjustable = false)) 
+    return Implicit(model = model, rate = rate, method = method)
+end
+
+# helper functions
+function explicit(models::Tuple)
+    explicit_models = []
+    for model in models
+        if model isa Explicit 
+            push!(explicit_models, model)
+        end
+    end
+    return explicit_models
+end
+# extension
+explicit(model) = explicit((model,))
+explicit(model::BalanceLaw) = explicit(Explicit(model))
+
+function implicit(models::Tuple)
+    explicit_models = []
+    for model in models
+        if model isa Implicit 
+            push!(explicit_models, model)
+        end
+    end
+    return explicit_models
+end
+# extension
+implicit(model) = implicit(())
+
+# Default to Explicit
+# TODO: Extend whatever struct an ODE solver is
+function construct_odesolver(method, rhs, state, Δt; t0 = 0, split_explicit_implicit = false)
+    # put error checking here 
+    explicit_rhs = explicit(rhs)
+    implicit_rhs = implicit(rhs)
+    number_implicit = length(implicit_rhs)
+    number_explicit = length(explicit_rhs) 
+    if (number_implicit != 0) | (number_explicit != 1)
+        error_string = "Explicit methods require one (and only one) explicit model"
+        error_string *= "\n for example, a tuple of the form  (Explicit(model),) or just (model,)"
+        @error(error_string)
+    end
+
+    explicit_model = explicit_rhs[1]
+
+    # Instantiate time stepping method    
+    odesolver = method(
+        explicit_rhs.model,
+        state;
+        dt = Δt,
+        t0 = t0,
+        split_explicit_implicit = split_explicit_implicit
+    )
+    return odesolver
+end
+
+# IMEX
+function construct_odesolver(timestepper::IMEX, rhs, state, Δt; t0 = 0, split_explicit_implicit = false)
+    # put error checking here 
+    implicit_rhs = implicit(rhs)
+    explicit_rhs = explicit(rhs)
+    number_implicit = length(implicit_rhs)
+    number_explicit = length(explicit_rhs) 
+    if (number_implicit != 1) | (number_explicit != 1)
+        error_string = "IMEX methods require 1 implicit model and one explicit model"
+        error_string *= "\n for example, a tuple of the form  (Explicit(model), Implicit(linear_model),)"
+        @error(error_string)
+    end
+    explicit_rhs = explicit_rhs[1]
+    implicit_rhs = implicit_rhs[1]
+
+    # Instantiate time stepping method    
+    odesolver = timestepper.method(
+        explicit_rhs.model,
+        implicit_rhs.model,
+        implicit_rhs.method,
+        state;
+        dt = Δt,
+        t0 = t0,
+        split_explicit_implicit = split_explicit_implicit
+    )
+    return odesolver
+end

--- a/experiments/SlabOcean/parameters_initialconditions.jl
+++ b/experiments/SlabOcean/parameters_initialconditions.jl
@@ -1,0 +1,247 @@
+########
+# Set up parameters
+# - ICTH = parameter for Thatcher & Jablonowski initial conditions 
+#   (see http://www-personal.umich.edu/~cjablono/DCMIP-2016_TestCaseDocument_10June2016.pdf)
+########
+parameters = (
+    a        = get_planet_parameter(:planet_radius),
+    Ω        = get_planet_parameter(:Omega),
+    g        = get_planet_parameter(:grav),
+    κ        = get_planet_parameter(:kappa_d),
+    R_d      = get_planet_parameter(:R_d),
+    R_v      = get_planet_parameter(:R_v),
+    cv_d     = get_planet_parameter(:cv_d),
+    cv_v     = get_planet_parameter(:cv_v),
+    cv_l     = get_planet_parameter(:cv_l),
+    cv_i     = get_planet_parameter(:cv_i),
+    cp_d     = get_planet_parameter(:cp_d), 
+    cp_v     = get_planet_parameter(:cp_v), 
+    cp_l     = get_planet_parameter(:cp_l),
+    cp_i     = get_planet_parameter(:cp_i),
+    molmass_ratio = get_planet_parameter(:molmass_dryair)/get_planet_parameter(:molmass_water),
+    γ        = get_planet_parameter(:cp_d)/get_planet_parameter(:cv_d),
+    pₒ       = get_planet_parameter(:MSLP),
+    pₜᵣ      = get_planet_parameter(:press_triple),
+    Tₜᵣ      = get_planet_parameter(:T_triple),
+    T_0      = get_planet_parameter(:T_0),
+    LH_v0    = get_planet_parameter(:LH_v0), 
+    e_int_v0 = get_planet_parameter(:e_int_v0),
+    e_int_i0 = get_planet_parameter(:e_int_i0),
+    H        = 30e3,   # domain height [m]
+    k        = 3.0,    # ICTH: power used for temperture field 
+    Γ        = 0.005,  # ICTH: lapse rate [K / m]
+    T_E      = 300,    # ICTH: surface temperature horizontally averaged [K]
+    T_P      = 271.0,  # ICTH: surface temperature at the pole [K]
+    b        = 2.0,    # ICTH: half-width parameter
+    z_t      = 15e3,   # ICTH: max height of the zonal wind perturbation [m]
+    λ_c      = π / 9,  # ICTH: longitude of the zonal wind perturbation centerpoint 
+    ϕ_c      = 2π / 9, # ICTH: latitude of the zonal wind perturbation centerpoint
+    V_p      = 1.0,    # ICTH: max amplitude of the zonal wind perturbation [m / s]
+    ϕ_w      = 2π/9,   # ICTH: specific humidity latitudinal width parameter
+    p_w      = 3.4e4,  # ICTH: specific humidity vertical pressure width parameter
+    q₀       = 0.018,  # ICTH: max specific humidity amplitude
+    qₜ       = 1e-12,  # ICTH: specific humidity above artificial tropopause
+    Mᵥ       = 0.608,  # ICTH: constant for virtual temperature conversion
+    ΔT       = 29.0,   # equator-pole SST difference: fixed SST runs only
+    Tₘᵢₙ     = 271.0,  # polar SST [K]: fixed SST runs only
+    Δϕ       = 26π/180.0,  # latitudinal width (standard deviation) of the SST kernel: fixed SST runs only
+    day      = 86400,  # length of day [s]
+    T_ref    = 255,    # reference temperature [K]
+    τ_precip = 100.0,  # precipitation timescale [s]
+    p0       = 1e5,    # surface pressure [Pa] 
+    Cₑ       = 0.0015, # bulk transfer coefficient for sensible heat
+    Cₗ       = 0.0015, # bulk transfer coefficient for latent heat
+    c_o = 3.93e3,   # specific heat for ocean  [J / K / kg]
+    T_h = 280.0,      # initial temperature of surface ocean layer [K]
+    h_o = 100.0,      # depth of the modelled ocean mixed layer [m]
+    F_sol = 1361.0,   # incoming solar TOA radiation [W / m^2]
+    τ = 0.9,        # atmospheric transmissivity 
+    α = 0.5,        # surface albedo    
+    σ = 5.67e-8,    # Steffan Boltzmann constant [kg / s^3 / K^4]
+    ϵ = 0.98,       # broadband emissivity / absorptivity
+    F_a = 0.0,      # LW flux from the atmosphere [W / m^2]
+    ρ_o = 1026.0,     # density for ocean [kg / m^3]
+    Q_0 = 10.0,       # Q-flux amplitude [W / m^2]
+    L_w = 16.0,       # width of the Q-flux region (radians)
+    diurnal_period = 24*60*60, # idealized daily cycle period [s]
+)
+
+# Mask to pick out the coupled boundary in the MPIStateArrays (here at altitude = 0 m)
+epss = sqrt(eps(Float64))
+boundary_mask( 𝒫, xc, yc, zc ) = @. abs(( xc^2 + yc^2 + zc^2 )^0.5 - 𝒫.a) < epss
+
+########
+# Set up inital conditions
+########
+
+# 1. Land (ocean) initial condition 
+T_sfc₀(𝒫, x, y, z) = boundary_mask(𝒫, x, y, z ) * 0.5 * (𝒫.T_E + 𝒫.T_P)
+
+# 2. Atmos (single stack) initial conditions
+# additional initial condition parameters
+T₀(𝒫)   = 0.5 * (𝒫.T_E + 𝒫.T_P)
+A(𝒫)    = 1.0 / 𝒫.Γ
+B(𝒫)    = (T₀(𝒫) - 𝒫.T_P) / T₀(𝒫) / 𝒫.T_P
+C(𝒫)    = 0.5 * (𝒫.k + 2) * (𝒫.T_E - 𝒫.T_P) / 𝒫.T_E / 𝒫.T_P
+H(𝒫)    = 𝒫.R_d * T₀(𝒫) / 𝒫.g
+d_0(𝒫)  = 𝒫.a / 6
+
+# convenience functions that only depend on height
+τ_z_1(𝒫,r)   = exp(𝒫.Γ * (r - 𝒫.a) / T₀(𝒫))
+τ_z_2(𝒫,r)   = 1 - 2 * ((r - 𝒫.a) / 𝒫.b / H(𝒫))^2
+τ_z_3(𝒫,r)   = exp(-((r - 𝒫.a) / 𝒫.b / H(𝒫))^2)
+τ_1(𝒫,r)     = 1 / T₀(𝒫) * τ_z_1(𝒫,r) + B(𝒫) * τ_z_2(𝒫,r) * τ_z_3(𝒫,r)
+τ_2(𝒫,r)     = C(𝒫) * τ_z_2(𝒫,r) * τ_z_3(𝒫,r)
+τ_int_1(𝒫,r) = A(𝒫) * (τ_z_1(𝒫,r) - 1) + B(𝒫) * (r - 𝒫.a) * τ_z_3(𝒫,r)
+τ_int_2(𝒫,r) = C(𝒫) * (r - 𝒫.a) * τ_z_3(𝒫,r)
+F_z(𝒫,r)     = (1 - 3 * ((r - 𝒫.a) / 𝒫.z_t)^2 + 2 * ((r - 𝒫.a) / 𝒫.z_t)^3) * ((r - 𝒫.a) ≤ 𝒫.z_t)
+
+# convenience functions that only depend on longitude and latitude
+d(𝒫,λ,ϕ)     = 𝒫.a * acos(sin(ϕ) * sin(𝒫.ϕ_c) + cos(ϕ) * cos(𝒫.ϕ_c) * cos(λ - 𝒫.λ_c))
+c3(𝒫,λ,ϕ)    = cos(π * d(𝒫,λ,ϕ) / 2 / d_0(𝒫))^3
+s1(𝒫,λ,ϕ)    = sin(π * d(𝒫,λ,ϕ) / 2 / d_0(𝒫))
+cond(𝒫,λ,ϕ)  = (0 < d(𝒫,λ,ϕ) < d_0(𝒫)) * (d(𝒫,λ,ϕ) != 𝒫.a * π)
+
+# base-state thermodynamic variables
+I_T(𝒫,ϕ,r)   = (cos(ϕ) * r / 𝒫.a)^𝒫.k - 𝒫.k / (𝒫.k + 2) * (cos(ϕ) * r / 𝒫.a)^(𝒫.k + 2)
+Tᵥ(𝒫,ϕ,r)    = (τ_1(𝒫,r) - τ_2(𝒫,r) * I_T(𝒫,ϕ,r))^(-1) * (𝒫.a/r)^2
+p(𝒫,ϕ,r)     = 𝒫.pₒ * exp(-𝒫.g / 𝒫.R_d * (τ_int_1(𝒫,r) - τ_int_2(𝒫,r) * I_T(𝒫,ϕ,r)))
+q(𝒫,ϕ,r)     = (p(𝒫,ϕ,r) > 𝒫.p_w) ? 𝒫.q₀ * exp(-(ϕ / 𝒫.ϕ_w)^4) * exp(-((p(𝒫,ϕ,r) - 𝒫.pₒ) / 𝒫.p_w)^2) : 𝒫.qₜ
+
+# base-state velocity variables
+U(𝒫,ϕ,r)  = 𝒫.g * 𝒫.k / 𝒫.a * τ_int_2(𝒫,r) * Tᵥ(𝒫,ϕ,r) * ((cos(ϕ) * r / 𝒫.a)^(𝒫.k - 1) - (cos(ϕ) * r / 𝒫.a)^(𝒫.k + 1))
+u(𝒫,ϕ,r)  = -𝒫.Ω * r * cos(ϕ) + sqrt((𝒫.Ω * r * cos(ϕ))^2 + r * cos(ϕ) * U(𝒫,ϕ,r))
+v(𝒫,ϕ,r)  = 0.0
+w(𝒫,ϕ,r)  = 0.0
+
+# velocity perturbations
+δu(𝒫,λ,ϕ,r)  = -16 * 𝒫.V_p / 3 / sqrt(3) * F_z(𝒫,r) * c3(𝒫,λ,ϕ) * s1(𝒫,λ,ϕ) * (-sin(𝒫.ϕ_c) * cos(ϕ) + cos(𝒫.ϕ_c) * sin(ϕ) * cos(λ - 𝒫.λ_c)) / sin(d(𝒫,λ,ϕ) / 𝒫.a) * cond(𝒫,λ,ϕ)
+δv(𝒫,λ,ϕ,r)  = 16 * 𝒫.V_p / 3 / sqrt(3) * F_z(𝒫,r) * c3(𝒫,λ,ϕ) * s1(𝒫,λ,ϕ) * cos(𝒫.ϕ_c) * sin(λ - 𝒫.λ_c) / sin(d(𝒫,λ,ϕ) / 𝒫.a) * cond(𝒫,λ,ϕ)
+δw(𝒫,λ,ϕ,r)  = 0.0
+
+# CliMA prognostic variables
+# compute the total energy
+uˡᵒⁿ(𝒫,λ,ϕ,r)   = u(𝒫,ϕ,r) + δu(𝒫,λ,ϕ,r)
+uˡᵃᵗ(𝒫,λ,ϕ,r)   = v(𝒫,ϕ,r) + δv(𝒫,λ,ϕ,r)
+uʳᵃᵈ(𝒫,λ,ϕ,r)   = w(𝒫,ϕ,r) + δw(𝒫,λ,ϕ,r)
+
+# cv_m and R_m for moist experiment
+cv_m(𝒫,ϕ,r)  = 𝒫.cv_d + (𝒫.cv_v - 𝒫.cv_d) * q(𝒫,ϕ,r)
+R_m(𝒫,ϕ,r) = 𝒫.R_d * (1 + (𝒫.molmass_ratio - 1) * q(𝒫,ϕ,r))
+
+T(𝒫,ϕ,r) = Tᵥ(𝒫,ϕ,r) / (1 + 𝒫.Mᵥ * q(𝒫,ϕ,r)) 
+e_int(𝒫,λ,ϕ,r)  = cv_m(𝒫,ϕ,r) * (T(𝒫,ϕ,r) - 𝒫.T_0) + q(𝒫,ϕ,r) * 𝒫.e_int_v0
+e_kin(𝒫,λ,ϕ,r)  = 0.5 * ( uˡᵒⁿ(𝒫,λ,ϕ,r)^2 + uˡᵃᵗ(𝒫,λ,ϕ,r)^2 + uʳᵃᵈ(𝒫,λ,ϕ,r)^2 )
+e_pot(𝒫,λ,ϕ,r)  = 𝒫.g * r
+
+ρ₀(𝒫,λ,ϕ,r)    = p(𝒫,ϕ,r) / R_m(𝒫,ϕ,r) / T(𝒫,ϕ,r)
+ρuˡᵒⁿ(𝒫,λ,ϕ,r) = ρ₀(𝒫,λ,ϕ,r) * uˡᵒⁿ(𝒫,λ,ϕ,r)
+ρuˡᵃᵗ(𝒫,λ,ϕ,r) = ρ₀(𝒫,λ,ϕ,r) * uˡᵃᵗ(𝒫,λ,ϕ,r)
+ρuʳᵃᵈ(𝒫,λ,ϕ,r) = ρ₀(𝒫,λ,ϕ,r) * uʳᵃᵈ(𝒫,λ,ϕ,r)
+ρe(𝒫,λ,ϕ,r) = ρ₀(𝒫,λ,ϕ,r) * (e_int(𝒫,λ,ϕ,r) + e_kin(𝒫,λ,ϕ,r) + e_pot(𝒫,λ,ϕ,r))
+ρq(𝒫,λ,ϕ,r) = ρ₀(𝒫,λ,ϕ,r) * q(𝒫,ϕ,r)
+
+# Cartesian Representation (boiler plate really)
+ρ₀ᶜᵃʳᵗ(𝒫, x...)  = ρ₀(𝒫, lon(x...), lat(x...), rad(x...))
+ρu⃗₀ᶜᵃʳᵗ(𝒫, x...) = (   ρuʳᵃᵈ(𝒫, lon(x...), lat(x...), rad(x...)) * r̂(x...)
+                     + ρuˡᵃᵗ(𝒫, lon(x...), lat(x...), rad(x...)) * ϕ̂(x...)
+                     + ρuˡᵒⁿ(𝒫, lon(x...), lat(x...), rad(x...)) * λ̂(x...) )
+ρeᶜᵃʳᵗ(𝒫, x...) = ρe(𝒫, lon(x...), lat(x...), rad(x...))
+ρqᶜᵃʳᵗ(𝒫, x...) = ρq(𝒫, lon(x...), lat(x...), rad(x...))
+
+
+#####
+# Held-Suarez Forcing
+#####
+struct HeldSuarezForcing{S} <: AbstractPhysicsComponent
+    parameters::S
+end
+
+FT = Float64
+day = 86400
+held_suarez_parameters = (;
+    k_a = FT(1 / (40 * day)),
+    k_f = FT(1 / day),
+    k_s = FT(1 / (4 * day)),
+    ΔT_y = FT(65),
+    Δθ_z = FT(10),
+    T_equator = FT(294),
+    T_min = FT(200),
+    σ_b = FT(7 / 10),
+    R_d  = parameters.R_d,
+    day  = parameters.day,
+    grav = parameters.g,
+    cp_d = parameters.cp_d,
+    cv_d = parameters.cv_d,
+    MSLP = parameters.p0,  
+)
+
+######
+# Modified Held-Suarez Forcing
+######
+function calc_component!(
+    source,
+    hsf::HeldSuarezForcing,
+    state,
+    aux,
+    physics,
+)
+    FT = eltype(state)
+    
+    _R_d  = hsf.parameters.R_d
+    _day  = hsf.parameters.day
+    _grav = hsf.parameters.grav
+    _cp_d = hsf.parameters.cp_d
+    _cv_d = hsf.parameters.cv_d
+    _p0   = hsf.parameters.MSLP  
+
+    # Extract the state
+    ρ = state.ρ
+    ρu = state.ρu
+    ρe = state.ρe
+    Φ = aux.Φ
+    
+    x = aux.x
+    y = aux.y
+    z = aux.z
+    coord = @SVector[x,y,z]
+
+    p = calc_pressure(physics.eos, state, aux, physics.parameters)
+    T = p / (ρ * _R_d)
+
+    # Held-Suarez parameters
+    k_a  = hsf.parameters.k_a
+    k_f  = hsf.parameters.k_f
+    k_s  = hsf.parameters.k_s
+    ΔT_y = hsf.parameters.ΔT_y
+    Δθ_z = hsf.parameters.Δθ_z
+    T_equator = hsf.parameters.T_equator
+    T_min = hsf.parameters.T_min
+    σ_b = hsf.parameters.σ_b
+
+    # Held-Suarez forcing
+    φ = @inbounds asin(coord[3] / norm(coord, 2))
+
+    #TODO: replace _p0 with dynamic surfce pressure in Δσ calculations to account
+    #for topography, but leave unchanged for calculations of σ involved in T_equil
+    σ = p / _p0
+    exner_p = σ^(_R_d / _cp_d)
+    Δσ = (σ - σ_b) / (1 - σ_b)
+    height_factor = max(0, Δσ)
+    T_equil = (T_equator - ΔT_y * sin(φ)^2 - Δθ_z * log(σ) * cos(φ)^2) * exner_p
+    T_equil = max(T_min, T_equil)
+    k_T = k_a + (k_s - k_a) * height_factor * cos(φ)^4
+    k_v = k_f * height_factor
+
+    # horizontal projection
+    k = coord / norm(coord)
+    P = I - k * k'
+
+    # Apply Held-Suarez forcing
+    source.ρu -= k_v * P * ρu
+    source.ρe -= k_T * ρ * _cv_d * (T - T_equil)
+    return nothing
+end
+
+
+

--- a/experiments/SlabOcean/physics/advection.jl
+++ b/experiments/SlabOcean/physics/advection.jl
@@ -1,0 +1,96 @@
+struct NonlinearAdvection{𝒯} <: AbstractTerm end
+struct LinearAdvection{𝒯} <: AbstractTerm end
+struct VeryLinearAdvection{𝒯} <: AbstractTerm end
+
+@inline calc_component!(flux, ::Nothing, _...) = nothing
+@inline calc_component!(flux, ::AbstractTerm, _...) = nothing
+
+@inline function calc_component!(flux, ::NonlinearAdvection{(:ρ, :ρu, :ρθ)}, state, aux, physics)
+    ρ  = state.ρ
+    ρu = state.ρu
+    ρθ = state.ρθ
+    
+    u = ρu / ρ
+
+    flux.ρ  += ρu
+    flux.ρu += ρu ⊗ u
+    flux.ρθ += ρθ * u
+
+    nothing
+end
+
+@inline function calc_component!(flux, ::NonlinearAdvection{(:ρ, :ρu, :ρe)}, state, aux, physics)
+    ρ   = state.ρ
+    ρu  = state.ρu
+    ρe  = state.ρe
+    ρq  = state.ρq
+    eos = physics.eos
+    parameters = physics.parameters
+
+    p = calc_pressure(eos, state, aux, parameters)
+    u = ρu / ρ
+
+    flux.ρ  += ρu
+    flux.ρu += ρu ⊗ u
+    flux.ρe += (ρe + p) * u
+    flux.ρq += ρq * u
+
+    nothing
+end
+
+@inline function calc_component!(flux, ::LinearAdvection{(:ρ, :ρu, :ρe)}, state, aux, physics)
+    ρu  = state.ρu
+    ρᵣ  = aux.ref_state.ρ
+    pᵣ  = aux.ref_state.p
+    ρeᵣ = aux.ref_state.ρe
+
+    flux.ρ  += ρu
+    flux.ρe += (ρeᵣ + pᵣ) * ρu / ρᵣ 
+
+    nothing
+end
+
+@inline function calc_component!(flux, ::VeryLinearAdvection{(:ρ, :ρu, :ρe)}, state, aux, physics)
+    # states
+    ρ   = state.ρ
+    ρu  = state.ρu
+    ρe  = state.ρe
+    ρq  = state.ρq
+
+    # thermodynamics
+    eos = physics.eos
+    parameters = physics.parameters
+    p = calc_very_linear_pressure(eos, state, aux, parameters)
+
+    # Reference states
+    ρᵣ  = aux.ref_state.ρ
+    ρuᵣ = aux.ref_state.ρu
+    ρeᵣ = aux.ref_state.ρe
+    ρqᵣ = aux.ref_state.ρq
+    pᵣ  = aux.ref_state.p
+
+    # derived states
+    u = ρu / ρᵣ - ρ * ρuᵣ / (ρᵣ^2)
+    q = ρq / ρᵣ - ρ * ρqᵣ / (ρᵣ^2)
+    e = ρe / ρᵣ - ρ * ρeᵣ / (ρᵣ^2)
+
+    # derived reference states
+    uᵣ = ρuᵣ / ρᵣ
+    qᵣ = ρqᵣ / ρᵣ
+    eᵣ = ρeᵣ / ρᵣ
+
+    # can be simplified, but written this way to look like the VeryLinearKGVolumeFlux
+    
+    flux.ρ   += ρᵣ * u + ρ * uᵣ # this is just ρu
+    flux.ρu  += p * I + ρᵣ .* (uᵣ .* u' + u .* uᵣ') 
+    flux.ρu  += (ρ .* uᵣ) .* uᵣ' 
+    flux.ρe  += (ρᵣ * eᵣ + pᵣ) * u
+    flux.ρe  += (ρᵣ * e + ρ * eᵣ + p) * uᵣ
+    flux.ρq  += ρᵣ * qᵣ * u + (ρᵣ * q + ρ * qᵣ) * uᵣ
+
+    # flux.ρ  += ρu
+    # flux.ρu += p * I
+    # flux.ρe += (ρeᵣ + pᵣ) * ρu / ρᵣ 
+
+    nothing
+end

--- a/experiments/SlabOcean/physics/coriolis.jl
+++ b/experiments/SlabOcean/physics/coriolis.jl
@@ -1,0 +1,44 @@
+abstract type AbstractCoriolis <: AbstractTerm end
+
+struct DeepShellCoriolis <: AbstractCoriolis end
+struct ThinShellCoriolis <: AbstractCoriolis end
+struct BetaPlaneCoriolis <: AbstractCoriolis end
+
+@inline calc_component!(source, ::Nothing, state, _...) = nothing
+@inline calc_component!(source, ::AbstractTerm, _...) = nothing
+
+@inline function calc_component!(source, ::DeepShellCoriolis, state, aux, physics)
+    ρu = state.ρu
+
+    Ω  = @SVector [-0, -0, physics.parameters.Ω]
+
+    source.ρu -= 2Ω × ρu
+
+    nothing
+end
+
+@inline function calc_component!(source, ::ThinShellCoriolis, state, aux, physics)
+    ρu = state.ρu
+    
+    k  = vertical_unit_vector(physics.orientation, aux)
+    Ω  = @SVector [-0, -0, physics.parameters.Ω]
+
+    source.ρu -= (2Ω ⋅ k) * (k × ρu)
+    
+    nothing
+end
+
+@inline function calc_component!(source, ::BetaPlaneCoriolis, state, aux, physics)
+    ρu = state.ρu
+    y  = aux.y
+    f₀ = physics.parameters.f₀
+    β  = physics.parameters.β
+
+    k  = vertical_unit_vector(physics.orientation, aux)
+
+    f = f₀ + β * y
+    
+    source.ρu -= f * (k × ρu)
+
+    nothing
+end

--- a/experiments/SlabOcean/physics/diffusion.jl
+++ b/experiments/SlabOcean/physics/diffusion.jl
@@ -1,0 +1,46 @@
+abstract type AbstractDiffusion  <: AbstractPhysicsComponent end
+
+struct ConstantViscosity{𝒯} <: AbstractDiffusion end
+
+# @inline function calc_diffusive_flux_argument!(grad, ::Nothing, _...) 
+#     grad.∇ρ = 0
+#     grad.∇u = @SVector [0, 0, 0]
+#     grad.∇θ = 0
+
+#     return nothing
+# end
+
+# @inline function calc_diffusive_flux_argument!(grad, diff::ConstantViscosity, state, aux, physics)  
+#     ρ = state.ρ
+#     ρu = state.ρu
+#     ρθ = state.ρθ
+
+#     u = ρu / ρ
+#     θ = ρθ / ρ
+
+#     grad.∇ρ = ρ
+#     grad.∇u = u
+#     grad.∇θ = θ
+
+#     return nothing
+# end
+
+# @inline function calc_diffusive_flux!(gradflux, ::Nothing, _...)
+#     gradflux.μ∇ρ = @SVector [0, 0, 0]
+#     gradflux.ν∇u = @SMatrix zeros(3,3)
+#     gradflux.κ∇θ = @SVector [0, 0, 0]
+
+#     return nothing
+# end
+
+# @inline function calc_diffusive_flux!(gradflux, ::ConstantViscosity, grad, state, aux, physics)
+#     μ = physics.params.μ * I
+#     ν = physics.params.ν * I
+#     κ = physics.params.κ * I
+
+#     gradflux.μ∇ρ = -μ * grad.∇ρ
+#     gradflux.ν∇u = -ν * grad.∇u
+#     gradflux.κ∇θ = -κ * grad.∇θ
+
+#     return nothing
+# end

--- a/experiments/SlabOcean/physics/euler.jl
+++ b/experiments/SlabOcean/physics/euler.jl
@@ -1,0 +1,38 @@
+struct CompressibleEuler <: AbstractTerm end
+struct LinearCompressibleEuler <: AbstractTerm end
+
+@inline calc_component!(flux, ::Nothing, _...) = nothing
+@inline calc_component!(flux, ::AbstractTerm, _...) = nothing
+
+@inline function calc_component!(flux, ::CompressibleEuler, state, aux, physics)
+    ρ   = state.ρ
+    ρu  = state.ρu
+    ρe  = state.ρe
+    ρq  = state.ρq
+    eos = physics.eos
+    parameters = physics.parameters
+
+    p = calc_pressure(eos, state, aux, parameters)
+    u = ρu / ρ
+
+    flux.ρ  += ρu
+    flux.ρu += ρu ⊗ u + p * I
+    flux.ρe += (ρe + p) * u
+    flux.ρq += ρq * u
+
+    nothing
+end
+
+@inline function calc_component!(flux, ::LinearCompressibleEuler, state, aux, physics)
+    ρu  = state.ρu
+    ρᵣ  = aux.ref_state.ρ
+    pᵣ  = aux.ref_state.p
+    ρeᵣ = aux.ref_state.ρe
+    
+    p = calc_linear_pressure(eos, state, aux, parameters)
+
+    flux.ρ  += ρu + p * I
+    flux.ρe += (ρeᵣ + pᵣ) * ρu / ρᵣ 
+
+    nothing
+end

--- a/experiments/SlabOcean/physics/gravity.jl
+++ b/experiments/SlabOcean/physics/gravity.jl
@@ -1,0 +1,42 @@
+abstract type AbstractGravity <: AbstractTerm end
+
+struct Gravity <: AbstractGravity end
+struct Buoyancy{𝒯} <: AbstractGravity end
+struct FluctuationGravity <: AbstractGravity end
+
+@inline calc_component!(source, ::Nothing, state, _...) = nothing
+
+@inline function calc_component!(source, ::Gravity, state, aux, physics)
+    ρ  = state.ρ
+    ∇Φ = aux.∇Φ
+   
+    source.ρu -= ρ * ∇Φ 
+
+    nothing
+end
+
+@inline function calc_component!(source, ::Buoyancy{(:ρ, :ρu, :ρθ)}, state, aux, physics)
+    ρθ = state.ρθ
+    α = physics.parameters.α 
+    g = physics.parameters.g
+    orientation = physics.orientation
+
+    k = vertical_unit_vector(orientation, aux)
+        
+    source.ρu -= -α * g * k * ρθ
+
+    nothing
+end
+
+# FluctuationGravity Components
+@inline calc_fluctuation_component!(source, _...) = nothing
+@inline calc_component!(source, ::FluctuationGravity, _...) = nothing
+
+@inline function calc_fluctuation_component!(source, ::FluctuationGravity, state_1, state_2, aux_1, aux_2)
+        ρ_1, ρ_2 = state_1.ρ, state_2.ρ
+        Φ_1, Φ_2 = aux_1.Φ, aux_2.Φ
+        α = ave(ρ_1, ρ_2) * 0.5
+        source.ρu -= α * (Φ_1 - Φ_2) * I
+        
+        nothing
+end

--- a/experiments/SlabOcean/physics/microphysics.jl
+++ b/experiments/SlabOcean/physics/microphysics.jl
@@ -1,0 +1,27 @@
+abstract type AbstractMicrophysics  <: AbstractPhysicsComponent end
+
+@Base.kwdef struct ZeroMomentMicrophysics <: AbstractMicrophysics end
+
+@inline calc_component!(source, ::Nothing, state, _...) = nothing
+
+@inline function calc_component!(source, ::ZeroMomentMicrophysics, state, aux, physics) 
+  ρ    = state.ρ
+  ρq   = state.ρq
+  Φ    = aux.Φ
+  eos  = physics.eos
+  τ    = physics.parameters.τ_precip
+  T_0  = physics.parameters.T_0 
+  cv_l = physics.parameters.cv_l
+
+  # we need the saturation excess in order to calculate the 
+  # source terms for prognostic variables
+  T    = calc_air_temperature(eos, state, aux, physics.parameters)
+  qᵥₛ  = calc_saturation_specific_humidity(ρ, T, physics.parameters) 
+  ρS   = max(0, ρq - ρ * qᵥₛ) # saturation excess
+  Iₗ   = cv_l * (T - T_0) # liquid internal energy
+
+  # source terms are proportional to the saturation excess
+  source.ρ  -= ρS / τ
+  source.ρe -= (Iₗ + Φ) * ρS / τ
+  source.ρq -= ρS / τ
+end

--- a/experiments/SlabOcean/physics/physics.jl
+++ b/experiments/SlabOcean/physics/physics.jl
@@ -1,0 +1,50 @@
+abstract type AbstractPhysicsComponent end
+abstract type AbstractTerm end
+
+"""
+    Physics
+
+    Essentially a NamedTuple, but one that returns `nothing` by default.
+    Example:
+        physics = Physics(diffusion = NiceDiffusion())
+        `physics.diffusion` returns NiceDiffusion()
+        `physics.coriolis` returns nothing
+
+    With great power comes great responsibility:
+        Great for flexibility, just like NamedTuple, but potential
+        errors pass silently (e.g, typos in keywords)
+"""
+struct Physics{𝒯} <: AbstractPhysicsComponent
+    components::𝒯
+end
+
+function Physics(; kwargs...)
+    components = (; collect(kwargs)...)
+    return Physics(components)
+end
+
+"""
+    Base module extensions
+"""
+function Base.getproperty(value::Physics, name::Symbol)
+    # Physics default for everything is `nothing`
+    components = getfield(value, :components, false)
+    return get(components, name, nothing)
+end
+
+function Base.propertynames(value::Physics)
+    components = getfield(value, :components, false)
+    return keys(components)
+end
+
+function Base.show(io::IO, physics::Physics)
+    color = :white
+    printstyled(io, "Physics(\n", color = color)
+    for name in propertynames(physics)
+        property = getproperty(physics, name)
+        print("  ")
+        printstyled(property, color = Int(rand(UInt8)))
+        print("\n")
+    end
+    printstyled(io, ")", color = color)
+end

--- a/experiments/SlabOcean/physics/pressure_force.jl
+++ b/experiments/SlabOcean/physics/pressure_force.jl
@@ -1,0 +1,27 @@
+struct PressureDivergence <: AbstractTerm end
+struct LinearPressureDivergence <: AbstractTerm end
+
+@inline calc_component!(flux, ::Nothing, _...) = nothing
+@inline calc_component!(flux, ::AbstractTerm, _...) = nothing
+
+@inline function calc_component!(flux, ::PressureDivergence, state, aux, physics)
+    eos = physics.eos
+    parameters = physics.parameters
+    
+    p = calc_pressure(eos, state, aux, parameters)
+
+    flux.ρu += p * I
+
+    nothing
+end
+
+@inline function calc_component!(flux, ::LinearPressureDivergence, state, aux, physics)
+    eos = physics.eos
+    parameters = physics.parameters
+
+    p = calc_linear_pressure(eos, state, aux, parameters)
+
+    flux.ρu += p * I
+
+    nothing
+end

--- a/experiments/SlabOcean/physics/temperature_profiles.jl
+++ b/experiments/SlabOcean/physics/temperature_profiles.jl
@@ -1,0 +1,39 @@
+abstract type TemperatureProfile{FT} end
+
+struct DecayingTemperatureProfile{FT} <: TemperatureProfile{FT}
+    "Virtual temperature at surface (K)"
+    T_virt_surf::FT
+    "Minimum virtual temperature at the top of the atmosphere (K)"
+    T_min_ref::FT
+    "Height scale over which virtual temperature drops (m)"
+    H_t::FT
+    function DecayingTemperatureProfile{FT}(
+        params::NamedTuple,
+        _T_virt_surf::FT,
+        _T_min_ref::FT,
+        H_t::FT = FT(params.R_d) * _T_virt_surf / FT(params.g),
+    ) where {FT}
+        return new{FT}(_T_virt_surf, _T_min_ref, H_t)
+    end
+end
+
+function (profile::DecayingTemperatureProfile)(params::NamedTuple, z::FT) where {FT}
+    R_d = params.R_d
+    g   = params.g
+    p₀  = params.pₒ
+
+    # Scale height for surface temperature
+    H_sfc = R_d * profile.T_virt_surf / g
+    H_t = profile.H_t
+    z′ = z / H_t
+    tanh_z′ = tanh(z′)
+
+    ΔTv = profile.T_virt_surf - profile.T_min_ref
+    Tv  = profile.T_virt_surf - ΔTv * tanh_z′
+
+    ΔTv′ = ΔTv / profile.T_virt_surf
+    p = -H_t * (z′ + ΔTv′ * (log(1 - ΔTv′ * tanh_z′) - log(1 + tanh_z′) + z′))
+    p /= H_sfc * (1 - ΔTv′^2)
+    p = p₀ * exp(p)
+    return (Tv, p)
+end

--- a/experiments/SlabOcean/physics/thermodynamics.jl
+++ b/experiments/SlabOcean/physics/thermodynamics.jl
@@ -1,0 +1,257 @@
+abstract type AbstractEquationOfState end
+abstract type AbstractIdealGas <: AbstractEquationOfState end
+
+struct BarotropicFluid <: AbstractEquationOfState end
+struct DryIdealGas <: AbstractIdealGas end
+struct MoistIdealGas <: AbstractIdealGas end
+
+@inline function calc_pressure(::BarotropicFluid, state, aux, params)
+    ρ  = state.ρ
+    cₛ = params.cₛ
+    ρₒ = params.ρₒ
+
+    return (cₛ * ρ)^2 / (2 * ρₒ)
+end
+
+@inline function calc_pressure(eos::DryIdealGas, state, aux, params)
+    ρ  = state.ρ
+
+    R_d = calc_gas_constant(eos, state, params)
+    T = calc_air_temperature(eos, state, aux, params)
+
+    return ρ * R_d * T
+end
+
+@inline function calc_pressure(eos::MoistIdealGas, state, aux, params)
+    ρ  = state.ρ
+
+    R_m = calc_gas_constant(eos, state, params)
+    T = calc_air_temperature(eos, state, aux, params)
+    
+    return ρ * R_m * T 
+end
+
+@inline function calc_linear_pressure(eos::DryIdealGas, state, aux, params)
+    ρ  = state.ρ
+    ρe = state.ρe
+    Φ  = aux.Φ
+    T_0  = params.T_0
+
+    γ = calc_heat_capacity_ratio(eos, state, params)
+    cv_d = calc_heat_capacity_at_constant_volume(eos, state, params)
+
+    return (γ - 1) * (ρe - ρ * Φ + ρ * cv_d * T_0) 
+end
+
+@inline function calc_linear_pressure(::MoistIdealGas, state, aux, params)
+    ρ  = state.ρ
+    ρe = state.ρe
+    ρ_q_tot = state.ρq 
+    ρ_q_liq = 0 # zero for now
+    ρ_q_ice = 0 # zero for now
+    Φ = aux.Φ
+    T_0  = params.T_0
+
+    γ    = calc_heat_capacity_ratio(DryIdealGas(), state, params)
+    cv_d = calc_heat_capacity_at_constant_volume(DryIdealGas(), state, params)
+
+    ρ_e_latent = (ρ_q_tot - ρ_q_liq) * params.e_int_v0 - ρ_q_ice * (params.e_int_v0 + params.e_int_i0)
+    
+    return (γ - 1) * (ρe - ρ * Φ - ρ_e_latent + ρ * cv_d * T_0)
+end
+
+@inline function calc_very_linear_pressure(eos::DryIdealGas, state, aux, params)
+    ρ  = state.ρ
+    ρu = state.ρu
+    ρe = state.ρe
+    Φ  = aux.Φ
+
+    # Reference states
+    ρᵣ  = aux.ref_state.ρ
+    ρuᵣ = aux.ref_state.ρu
+
+    γ  = calc_heat_capacity_ratio(eos, state, params)
+
+    return (γ - 1) * (ρe - dot(ρuᵣ, ρu) / ρᵣ + ρ * dot(ρuᵣ, ρuᵣ) / (2*ρᵣ^2) - ρ * Φ)
+end
+
+@inline function calc_sound_speed(::BarotropicFluid, state, aux, params)
+    ρ = state.ρ
+    cₛ = params.cₛ 
+    ρₒ = params.ρₒ
+    
+    return cₛ * sqrt(ρ / ρₒ) 
+end
+
+@inline function calc_sound_speed(eos::DryIdealGas, state, aux, params)
+    ρ  = state.ρ
+
+    γ  = calc_heat_capacity_ratio(eos, state, params)
+    p  = calc_pressure(eos, state, aux, params)
+
+    return sqrt(γ * p / ρ)
+end
+
+@inline function calc_sound_speed(eos::MoistIdealGas, state, aux, params)
+    ρ  = state.ρ
+
+    γ  = calc_heat_capacity_ratio(eos, state, params)
+    p  = calc_pressure(eos, state, aux, params)
+
+    return sqrt(γ * p / ρ)
+end
+
+@inline function calc_ref_sound_speed(eos::DryIdealGas, state, aux, params)
+    p = aux.ref_state.p
+    ρ = aux.ref_state.ρ
+
+    γ = calc_heat_capacity_ratio(eos, state, params)
+
+    return sqrt(γ * p / ρ)
+end
+
+@inline function calc_ref_sound_speed(::MoistIdealGas, state, aux, params)
+    p = aux.ref_state.p
+    ρ = aux.ref_state.ρ
+
+    γ = calc_heat_capacity_ratio(DryIdealGas(), state, params)
+
+    return sqrt(γ * p / ρ)
+end
+
+@inline function calc_air_temperature(::DryIdealGas, state, aux, params)
+  ρ = state.ρ
+  ρu = state.ρu
+  ρe = state.ρe
+  Φ = aux.Φ
+  T_0 = params.T_0
+
+  cv_d = calc_heat_capacity_at_constant_volume(DryIdealGas(), state, params)
+
+  e_int = (ρe - ρu' * ρu / 2ρ - ρ * Φ) / ρ
+  T = T_0 + e_int / cv_d
+
+  return T
+end
+
+@inline function calc_air_temperature(eos::MoistIdealGas, state, aux, params)
+  ρ = state.ρ
+  ρu = state.ρu
+  ρe = state.ρe
+  q_tot = state.ρq / ρ
+  q_liq = 0.0 # zero for now
+  q_ice = 0.0 # zero for now
+  Φ = aux.Φ
+  T_0 = params.T_0
+  e_int_v0 = params.e_int_v0
+  e_int_i0 = params.e_int_i0
+
+  cv_m = calc_heat_capacity_at_constant_volume(eos, state, params)
+  
+  e_int = (ρe - ρu' * ρu / 2ρ - ρ * Φ) / ρ
+  T = T_0 + (e_int - (q_tot - q_liq) * e_int_v0 + q_ice * (e_int_v0 + e_int_i0)) / cv_m
+
+  return T
+end
+
+@inline function calc_total_specific_enthalpy(eos::DryIdealGas, state, aux, params)
+    ρ  = state.ρ
+    ρe = state.ρe
+
+    p  = calc_pressure(eos, state, aux, params)
+
+    return (ρe + p) / ρ
+end
+
+@inline function calc_total_specific_enthalpy(eos::MoistIdealGas, state, aux, params)
+    ρ  = state.ρ
+    ρe = state.ρe
+
+    p  = calc_pressure(eos, state, aux, params)
+
+    return (ρe + p) / ρ
+end
+
+@inline function calc_heat_capacity_at_constant_pressure(::DryIdealGas, state, params)
+    return params.cp_d
+end
+
+@inline function calc_heat_capacity_at_constant_pressure(::MoistIdealGas, state, params)
+    q_tot = state.ρq / state.ρ
+    q_liq = 0 # zero for now
+    q_ice = 0 # zero for now
+    cp_d  = params.cp_d
+    cp_v  = params.cp_v
+    cp_l  = params.cp_l
+    cp_i  = params.cp_i
+
+    cp_m  = cp_d + (cp_v - cp_d) * q_tot + (cp_l - cp_v) * q_liq + (cp_i - cp_v) * q_ice
+
+    return cp_m
+end
+
+@inline function calc_heat_capacity_at_constant_volume(::DryIdealGas, state, params)
+    return params.cv_d 
+end
+
+@inline function calc_heat_capacity_at_constant_volume(::MoistIdealGas, state, params)
+    q_tot = state.ρq / state.ρ
+    q_liq = 0 # zero for now
+    q_ice = 0 # zero for now   
+    cv_d  = params.cv_d
+    cv_v  = params.cv_v
+    cv_l  = params.cv_l
+    cv_i  = params.cv_i
+
+    cv_m  = cv_d + (cv_v - cv_d) * q_tot + (cv_l - cv_v) * q_liq + (cv_i - cv_v) * q_ice
+
+    return cv_m
+end
+
+@inline function calc_gas_constant(::DryIdealGas, state, params)
+    return params.R_d
+end
+
+@inline function calc_gas_constant(::MoistIdealGas, state, params)
+    q_tot = state.ρq / state.ρ
+    q_liq = 0 # zero for now
+    q_ice = 0 # zero for nov
+    R_d = params.R_d
+    molmass_ratio = params.molmass_ratio
+
+    R_m = R_d * (1 + (molmass_ratio - 1) * q_tot - molmass_ratio * (q_liq + q_ice))
+
+    return R_m
+end
+
+@inline function calc_heat_capacity_ratio(eos::AbstractEquationOfState, state, params)
+    cp = calc_heat_capacity_at_constant_pressure(eos, state, params)
+    cv = calc_heat_capacity_at_constant_volume(eos, state, params)
+    γ  = cp/cv
+
+    return γ
+end
+
+@inline function calc_saturation_vapor_pressure(T, params)
+    pₜᵣ   = params.pₜᵣ
+    R_v   = params.R_v
+    Tₜᵣ   = params.Tₜᵣ
+    T_0   = params.T_0
+    cp_v  = params.cp_v
+    cp_l  = params.cp_l
+    LH_v0 = params.LH_v0
+    
+    Δcp = cp_v - cp_l
+    pᵥₛ = pₜᵣ * (T / Tₜᵣ)^(Δcp / R_v) * exp((LH_v0 - Δcp * T_0) / R_v * (1 / Tₜᵣ - 1 / T))
+
+    return pᵥₛ
+end
+
+@inline function calc_saturation_specific_humidity(ρ, T, params)
+    R_v = params.R_v
+    
+    pᵥₛ = calc_saturation_vapor_pressure(T, params)
+    qt  = pᵥₛ / (ρ * R_v * T)
+    
+    return qt
+end

--- a/experiments/SlabOcean/run_OneSphericalShellWithSlabOcean.jl
+++ b/experiments/SlabOcean/run_OneSphericalShellWithSlabOcean.jl
@@ -1,0 +1,225 @@
+#!/usr/bin/env julia --project
+using CouplerMachine
+using Unitful
+
+include("utilities/boilerplate.jl")
+include("numerics/timestepper_abstractions.jl")
+include("balance_law_interface_slabocean.jl")
+
+########
+# Set up parameters and initial conditions
+########
+include("parameters_initialconditions.jl")
+
+FT = Float64
+
+# Collects tracer valus/fluxes for conservation checks
+mutable struct LogThatFlux{F}
+    A::F
+    B::F
+end
+
+########
+# Set up domain
+########
+
+# A: low atmos level (ocean)
+domainOcean = SphericalShell(
+    radius = parameters.a - parameters.H,
+    height = parameters.H,
+)
+
+# B: high atmos level (atmosphere)
+domainAtmos = SphericalShell(
+    radius = parameters.a,
+    height = parameters.H,
+)
+
+gridOcean = DiscretizedDomain(
+    domainOcean;
+    elements = (vertical = 4, horizontal = 8), 
+    polynomial_order = (vertical = 2, horizontal = 2),
+    overintegration_order = (vertical = 0, horizontal = 0),
+)
+
+gridAtmos = DiscretizedDomain(
+    domainAtmos;
+    elements = (vertical = 4, horizontal = 8), 
+    polynomial_order = (vertical = 2, horizontal = 2),
+    overintegration_order = (vertical = 0, horizontal = 0),
+)
+
+# ########
+# # Set up boundary conditions
+# ########
+
+oceanBC = (nothing, nothing, )
+
+# # Fixed SST:
+# T_sfc(𝒫, ϕ) = 𝒫.ΔT * exp(-ϕ^2 / 2 / 𝒫.Δϕ^2) + 𝒫.Tₘᵢₙ
+# AtmosSfcBC = BulkFormulaTemperature(
+#     drag_coef_temperature = (params, ϕ) -> params.Cₑ,
+#     drag_coef_moisture = (params, ϕ) -> params.Cₗ,
+#     surface_temperature = T_sfc,
+# )
+AtmosSfcBC = CoupledPrimarySlabOceanBC( parameters.Cₑ, parameters.Cₗ)
+atmosBC = ( AtmosSfcBC , DefaultBC(), )#DefaultBC(), ) inner, outer
+
+########
+# Set up model physics
+######## 
+
+FT = Float64
+
+ref_state = DryReferenceState(
+  DecayingTemperatureProfile{FT}(parameters, FT(290), FT(220), FT(8e3))
+)
+
+physicsOcean = Physics(
+    orientation = SphericalOrientation(),
+    parameters = parameters,
+)
+
+physicsAtmos = Physics(
+    orientation = SphericalOrientation(),
+    ref_state   = ref_state,
+    eos         = MoistIdealGas(),
+    lhs         = (
+        NonlinearAdvection{(:ρ, :ρu, :ρe)}(),
+        PressureDivergence(),
+    ),
+    sources     = (
+        DeepShellCoriolis(),
+        FluctuationGravity(),
+        ZeroMomentMicrophysics(),
+        HeldSuarezForcing(held_suarez_parameters),
+        FluxAccumulator(AtmosSfcBC),
+    ),
+    parameters = parameters,
+)
+
+linear_physicsAtmos = Physics(
+    orientation = physicsAtmos.orientation,
+    ref_state   = physicsAtmos.ref_state,
+    eos         = physicsAtmos.eos,
+    lhs         = (
+        LinearAdvection{(:ρ, :ρu, :ρe)}(),
+        LinearPressureDivergence(),
+    ),
+    sources     = (
+        FluctuationGravity(),
+    ),
+    parameters = parameters,
+)
+
+########
+# Set up model
+########
+
+modelOcean = SlabOceanModelSetup(
+    physics = physicsOcean,
+    boundary_conditions = oceanBC,
+    initial_conditions = (T_sfc = T_sfc₀,),
+    numerics = (flux = nothing, flux_second_order = nothing, direction = EveryDirection()),
+)
+
+modelAtmos = DryAtmosModel(
+    physics = physicsAtmos,
+    boundary_conditions = atmosBC, #atmosBC, 
+    initial_conditions = (ρ = ρ₀ᶜᵃʳᵗ, ρu = ρu⃗₀ᶜᵃʳᵗ, ρe = ρeᶜᵃʳᵗ, ρq = ρqᶜᵃʳᵗ),
+    numerics = (flux = LMARSNumericalFlux(),), #LMARSNumericalFlux;RoeNumericalFlux
+)
+
+linear_modelAtmos = DryAtmosModel(
+    physics = linear_physicsAtmos,
+    boundary_conditions = (DefaultBC(), DefaultBC()), # (Insulating, FreeSlip), (Insulating, FreeSlip) 
+    initial_conditions = modelAtmos.initial_conditions,
+    numerics = (flux = RefanovFlux(),),
+)
+
+########
+# Set up time steppers (could be done automatically in simulation)
+########
+
+nstepsOcean = 1
+nstepsAtmos = 1
+
+dx = min_node_distance(gridAtmos.numerical)
+cfl = 5 # 13 for 10 days, 7.5 for 200+ days
+Δt = cfl * dx / 330.0 * nstepsAtmos
+
+total_steps = 10000
+start_time = 0
+end_time = Δt * total_steps#30 * 24 * 3600
+
+methodOcean = SSPRK22Heuns
+methodAtmos = IMEX() 
+
+callbacks = (
+  Info(),
+  CFL(),
+  VTKState(
+    iteration = 100, #Int(floor(24*3600/Δt)), 
+    filepath = "./output/SphereSlabOcean"),
+    TMARCallback(),
+)
+
+########
+# Set up simulation
+########
+
+simOcean = CplSimulation(
+    modelOcean;
+    grid = gridOcean,
+    timestepper = (method = methodOcean, timestep = Δt / nstepsOcean),
+    time        = (start = start_time, finish = end_time),
+    nsteps      = nstepsOcean,
+    boundary_z = boundary_mask,
+    callbacks   = callbacks,
+)
+simAtmos = CplSimulation(
+    (Explicit(modelAtmos), Implicit(linear_modelAtmos),);
+    grid = gridAtmos,
+    timestepper = (method = methodAtmos, timestep = Δt / nstepsAtmos),
+    time        = (start = start_time, finish = end_time),
+    nsteps      = nstepsAtmos,
+    boundary_z = boundary_mask,
+    callbacks   = callbacks,
+)
+
+## Create a Coupler State object for holding import/export fields.
+coupler = CplState()
+coupler_register!(coupler, :SeaSurfaceTemerature, deepcopy(simOcean.state.T_sfc[simOcean.boundary]), simOcean.grid, DateTime(0), u"K") # value on top of domainA for calculating upward flux into domainB
+coupler_register!(coupler, :BoundaryEnergyFlux, deepcopy(simAtmos.state.F_ρe_accum[simAtmos.boundary]), simAtmos.grid, DateTime(0), u"J") # downward flux
+
+compOcean = (pre_step = preOcean, component_model = simOcean, post_step = postOcean)
+compAtmos = (pre_step = preAtmos, component_model = simAtmos, post_step = postAtmos)
+component_list = (domainOcean = compOcean, domainAtmos = compAtmos)
+
+cpl_solver = CplSolver(
+    component_list = component_list,
+    coupler = coupler,
+    coupling_dt = Δt,
+    t0 = FT(start_time),
+    fluxlog = LogThatFlux( zeros(total_steps) , zeros(total_steps) )
+)
+
+########
+# Run the simulation
+########
+
+evolve!(cpl_solver, total_steps)
+
+########
+# Check conservation
+########
+
+#using Plots
+fluxA = cpl_solver.fluxlog.A
+fluxB = cpl_solver.fluxlog.B
+
+fluxT = abs.(fluxA) .+ abs.(fluxB) 
+tme = collect(1:1:total_steps)
+rel_error = [ ((fluxT .- fluxT[1]) / fluxT[1]) ]
+# plot(tme .* cpl_solver.dt, rel_error, ylabel = "rel. error = (fluxT - fluxT[1]) / fluxT[1]", xlabel = "time (s)")
+# plot(tme .* cpl_solver.dt, [(fluxA .- fluxA[1])  (fluxB .- fluxB[1]) ],  label = ["Ocean Energy" "Atmos Energy"], xlabel = "time (s)", ylabel = "J / m2")

--- a/experiments/SlabOcean/simulations.jl
+++ b/experiments/SlabOcean/simulations.jl
@@ -1,0 +1,413 @@
+using ClimateMachine.Mesh.Grids: _x1, _x2, _x3, VerticalDirection
+
+abstract type AbstractSimulation end
+
+struct Simulation{𝒯,𝒰,𝒱,𝒲,𝒳,𝒴,L} <: AbstractSimulation
+    model::𝒯
+    grid::L
+    timestepper::𝒰
+    time::𝒱
+    callbacks::𝒲
+    rhs::𝒳
+    state::𝒴
+end
+
+function Simulation(model::ModelSetup; grid, timestepper, time, callbacks)
+    rhs = DGModel(
+        model, 
+        grid.numerical,
+        model.numerics.flux,
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+    ) 
+
+    FT = eltype(rhs.grid.vgeo)
+    state = init_ode_state(rhs, FT(0); init_on_cpu = true)
+    
+    return Simulation(model, grid, timestepper, time, callbacks, rhs, state)
+end
+
+function Simulation(model::DryAtmosModel; grid, timestepper, time, callbacks)
+    rhs = ESDGModel(
+        model, 
+        grid.numerical,
+        surface_numerical_flux_first_order = model.numerics.flux,
+        volume_numerical_flux_first_order = KGVolumeFlux(),
+    ) 
+
+    FT = eltype(rhs.grid.vgeo)
+    state = init_ode_state(rhs, FT(0); init_on_cpu = true)
+    
+    return Simulation(model, grid, timestepper, time, callbacks, rhs, state)
+end
+
+function Simulation(model::Tuple; grid, timestepper, time, callbacks)
+    rhs = []
+    for item in model
+        if typeof(item) <: DryAtmosModel
+            tmp = ESDGModel(
+                item,
+                grid.numerical,
+                surface_numerical_flux_first_order = item.numerics.flux,
+                volume_numerical_flux_first_order = KGVolumeFlux(),
+            )
+            push!(rhs, tmp)
+        elseif typeof(item) <: DryAtmosLinearModel
+            tmp = DGModel(
+                item,
+                grid.numerical,
+                item.numerics.flux,
+                CentralNumericalFluxSecondOrder(),
+                CentralNumericalFluxGradient();
+                direction = item.numerics.direction,
+            )
+            push!(rhs, tmp)
+        end
+    end
+    rhs = Tuple(rhs)
+
+    FT = eltype(rhs[1].grid.vgeo)
+    state = init_ode_state(rhs[1], FT(0); init_on_cpu = true)
+    
+    return Simulation(model, grid, timestepper, time, callbacks, rhs, state)
+end
+
+struct CplSimulation{𝒯,𝒰,𝒱,𝒲,𝒳,𝒴,L,B, CBV} <: AbstractSimulation
+    model::𝒯
+    grid::L
+    odesolver::𝒰
+    time::𝒱
+    callbacks::𝒲
+    rhs::𝒳
+    state::𝒴
+    nsteps::Int
+    boundary::B
+    cbvector::CBV
+end
+
+function CplSimulation(model; grid, timestepper, time, boundary_z = nothing, nsteps, callbacks)
+    rhs = DGModel(
+        model, 
+        grid.numerical,
+        model.numerics.flux,
+        model.numerics.flux_second_order,
+        CentralNumericalFluxGradient(),
+        direction = model.numerics.direction,
+    ) 
+
+    FT = eltype(rhs.grid.vgeo)
+    state = init_ode_state(rhs, FT(0); init_on_cpu = true)
+    param_set = model.physics.parameters
+    
+    xc = grid.numerical.vgeo[:, _x1:_x1, :]
+    yc = grid.numerical.vgeo[:, _x2:_x2, :]
+    zc = grid.numerical.vgeo[:, _x3:_x3, :]
+
+    boundary(boundary_z, xc, yc, zc) = isnothing(boundary_z) ? zc .^2 .< eps(FT) : boundary_z( parameters, xc, yc, zc )
+    boundary = boundary(boundary_z, xc, yc, zc)
+
+    simulation = Simulation(model, grid, timestepper, time, callbacks, rhs, state)
+    t0            = simulation.time.start
+    Δt            = timestepper.timestep
+
+    # Instantiate time stepping method    
+    odesolver = timestepper.method(rhs, state, dt = Δt, t0 = t0)
+
+    # Make callbacks from callbacks tuple
+    cbvector = create_callbacks(simulation, odesolver)
+
+    return CplSimulation(model, grid, odesolver, time, callbacks, rhs, state, nsteps, boundary, cbvector)
+end
+
+function CplSimulation(model::Tuple; grid, timestepper, time, boundary_z = nothing, nsteps, callbacks)
+    rhs = []
+    for item in model
+        if item isa Explicit
+            println("constructing explicit model") 
+            if item.model isa DryAtmosModel
+                tmp = Explicit(ESDGModel(
+                    item.model,
+                    grid.numerical,
+                    surface_numerical_flux_first_order = item.model.numerics.flux,
+                    volume_numerical_flux_first_order = KGVolumeFlux(),
+                ))
+            elseif item.model isa ModelSetup
+                tmp = Explicit(DGModel(
+                    item.model,
+                    grid.numerical,
+                    item.model.numerics.flux,
+                    CentralNumericalFluxSecondOrder(),
+                    CentralNumericalFluxGradient();
+                    direction = item.model.numerics.direction,
+                ))
+            else
+                println("what are you doing!?!??!")
+            end
+            push!(rhs, tmp)
+        elseif item isa Implicit
+            println("constructing implicit models")
+            if item.model isa DryAtmosModel 
+                tmp = Implicit(VESDGModel(
+                    item.model,
+                    grid.numerical,
+                    surface_numerical_flux_first_order = item.model.numerics.flux,
+                    volume_numerical_flux_first_order = LinearKGVolumeFlux(),
+                ))
+            elseif item.model isa ModelSetup
+                tmp = Implicit(DGModel(
+                    item.model,
+                    grid.numerical,
+                    item.model.numerics.flux,
+                    CentralNumericalFluxSecondOrder(),
+                    CentralNumericalFluxGradient();
+                    direction = item.model.numerics.direction,
+                ))
+            else
+                println("what are you doing!?!??!")
+            end
+            push!(rhs, tmp)
+        end
+    end
+    rhs = Tuple(rhs)
+
+    xc = grid.numerical.vgeo[:, _x1:_x1, :]
+    yc = grid.numerical.vgeo[:, _x2:_x2, :]
+    zc = grid.numerical.vgeo[:, _x3:_x3, :]
+
+    boundary(boundary_z, xc, yc, zc) = isnothing(boundary_z) ? zc .^2 .< eps(FT) : boundary_z( parameters, xc, yc, zc )
+    boundary = boundary(boundary_z, xc, yc, zc)
+
+    FT = eltype(grid.numerical.vgeo)
+    state = init_ode_state(rhs[1].model, FT(0); init_on_cpu = true)
+
+    simulation = Simulation(model[1].model, grid, timestepper, time, callbacks, rhs, state)
+    t0            = simulation.time.start
+    tend          = simulation.time.finish
+    Δt            = timestepper.timestep
+
+    # Instantiate time stepping method    
+    odesolver = timestepper.method.method(
+        rhs[1].model,
+        rhs[2].model,
+        LinearBackwardEulerSolver(ManyColumnLU(); isadjustable = false),
+        state;
+        dt = Δt,
+        t0 = t0,
+        split_explicit_implicit = false,
+    )
+
+    # Make callbacks from callbacks tuple
+    cbvector = create_callbacks(simulation, odesolver)
+
+    return CplSimulation(model, grid, odesolver, time, callbacks, rhs, state, nsteps, boundary, cbvector)
+end
+
+function initialize!(simulation::Simulation; overwrite = false)
+    if overwrite
+        simulation = Simulation(
+            model = simulation.model, 
+            timestepper = simulation.timestepper, 
+            time = simulation.time, 
+            callbacks = simulation.callbacks,
+        )
+    end
+
+    return nothing
+end
+
+function evolve!(simulation::Simulation; refDat = ())
+    # Unpack everything we need in this routine here
+    timestepper = simulation.timestepper
+    state = simulation.state
+    rhs   = simulation.rhs
+    grid  = simulation.grid
+
+    npoly = convention(grid.resolution.polynomial_order, Val(ndims(grid.domain)))
+
+    t0 = simulation.time.start
+    tend = simulation.time.finish
+    Δt = timestepper.timestep
+
+    # Set up overintegration and polynomial order-based spatial staggering
+    if haskey(grid.resolution, :overintegration_order)
+        nover = convention(grid.resolution.overintegration_order, Val(ndims(grid.domain)))
+    else
+        nover = (0, 0, 0)
+    end
+    staggering = get(simulation.model.numerics, :staggering, false)
+
+    # Perform overintegration filtering (only works if nover > 0)
+    overintegration_filter!(state, rhs, npoly, nover)
+
+    # Make right-hand side function with built-in filters
+    rhs = rhs_closure(rhs, npoly, nover, staggering = staggering)
+
+    # Instantiate time stepping method
+    odesolver = timestepper.method(rhs, state, dt = Δt, t0 = t0)
+
+    # Make callbacks from callbacks tuple
+    cbvector = create_callbacks(simulation, odesolver)
+
+    # Perform evolution of simulations
+    if isempty(cbvector)
+        solve!(state, odesolver; timeend = tend)
+    else
+        solve!(
+            state,
+            odesolver;
+            timeend = tend,
+            callbacks = cbvector,
+        )
+    end
+
+    # Check results against reference if StateCheck callback is used
+    # TODO: TB: I don't think this should live within this function
+    if any(typeof.(simulation.callbacks) .<: StateCheck)
+      check_inds = findall(typeof.(simulation.callbacks) .<: StateCheck)
+      @assert length(check_inds) == 1 "Only use one StateCheck in callbacks!"
+
+      ClimateMachine.StateCheck.scprintref(cbvector[check_inds[1]])
+      if length(refDat) > 0
+        @test ClimateMachine.StateCheck.scdocheck(cbvector[check_inds[1]], refDat)
+      end
+    end
+
+    return nothing
+end
+
+function evolve!(cpl_solver::CplSolver, numberofsteps; refDat = ())
+
+    # Perform evolution of simulations
+    solve!(
+        nothing,
+        cpl_solver;
+        numberofsteps = numberofsteps,
+        callbacks = cpl_solver.component_list.domainAtmos.component_model.cbvector,
+    )
+
+
+    # Check results against reference if StateCheck callback is used
+    # TODO: TB: I don't think this should live within this function
+    # if any(typeof.(simulation.callbacks) .<: StateCheck)
+    #   check_inds = findall(typeof.(simulation.callbacks) .<: StateCheck)
+    #   @assert length(check_inds) == 1 "Only use one StateCheck in callbacks!"
+
+    #   ClimateMachine.StateCheck.scprintref(cbvector[check_inds[1]])
+    #   if length(refDat) > 0
+    #     @test ClimateMachine.StateCheck.scdocheck(cbvector[check_inds[1]], refDat)
+    #   end
+    # end
+
+    return nothing
+end
+
+function rhs_closure(rhs, npoly, nover; staggering = false)
+    if staggering
+        function rhs_staggered(state_array, args...; kwargs...)
+            rhs(state_array, args...; kwargs...)
+            overintegration_filter!(state_array, rhs, npoly, nover)
+            staggering_filter!(state_array, rhs, npoly, nover)
+            return nothing
+        end
+
+        rhs_filtered = rhs_staggered
+    else
+        function rhs_unstaggered(state_array, args...; kwargs...)
+            rhs(state_array, args...; kwargs...)
+            overintegration_filter!(state_array, rhs, npoly, nover)
+            return nothing
+        end
+        
+        rhs_filtered = rhs_unstaggered
+    end
+
+    return rhs_filtered 
+end # returns a closure
+
+function evolve!(simulation::Simulation{<:Tuple}; refDat = ())
+    # Unpack everything we need in this routine here
+    model         = simulation.model[1]
+    state         = simulation.state
+    rhs           = simulation.rhs
+    grid          = simulation.grid.numerical
+    timestepper   = simulation.timestepper
+    t0            = simulation.time.start
+    tend          = simulation.time.finish
+    Δt            = timestepper.timestep
+    
+    # Instantiate time stepping method    
+    odesolver = timestepper.method(
+        rhs[1],
+        rhs[2],
+        LinearBackwardEulerSolver(ManyColumnLU(); isadjustable = false),
+        state;
+        dt = Δt,
+        t0 = t0,
+        split_explicit_implicit = false,
+    )
+
+    # Make callbacks from callbacks tuple
+    cbvector = create_callbacks(simulation, odesolver)
+
+    # Perform evolution of simulations
+    if isempty(cbvector)
+        solve!(state, odesolver; timeend = tend, adjustfinalstep = false)
+    else
+        solve!(
+            state,
+            odesolver;
+            timeend = tend,
+            callbacks = cbvector,
+            adjustfinalstep = false,
+        )
+    end
+
+    # Check results against reference if StateCheck callback is used
+    # TODO: TB: I don't think this should live within this function
+    if any(typeof.(simulation.callbacks) .<: StateCheck)
+      check_inds = findall(typeof.(simulation.callbacks) .<: StateCheck)
+      @assert length(check_inds) == 1 "Only use one StateCheck in callbacks!"
+
+      ClimateMachine.StateCheck.scprintref(cbvector[check_inds[1]])
+      if length(refDat) > 0
+        @test ClimateMachine.StateCheck.scdocheck(cbvector[check_inds[1]], refDat)
+      end
+    end
+
+    return nothing
+end
+
+function overintegration_filter!(state_array, rhs, npoly, nover)
+    if sum(nover) > 0
+        cutoff_order = npoly .+ 1 # yes this is confusing
+        cutoff = MassPreservingCutoffFilter(rhs.grid, cutoff_order)
+        num_state_prognostic = number_states(rhs.balance_law, Prognostic())
+        filterstates = 1:num_state_prognostic
+        ClimateMachine.Mesh.Filters.apply!(
+            state_array,
+            filterstates,
+            rhs.grid,
+            cutoff,
+        ) 
+    end
+
+    return nothing
+end
+
+function staggering_filter!(state_array, rhs, npoly, nover)
+    if sum(nover) > 0
+        cutoff_order = npoly .+ 0 # one polynomial order less than scalars
+        cutoff = MassPreservingCutoffFilter(rhs.grid, cutoff_order)
+        num_state_prognostic = number_states(rhs.balance_law, Prognostic())
+        filterstates = 2:4
+        ClimateMachine.Mesh.Filters.apply!(
+            state_array,
+            filterstates,
+            rhs.grid,
+            cutoff,
+        )
+       
+    end
+
+    return nothing
+end

--- a/experiments/SlabOcean/utilities/boilerplate.jl
+++ b/experiments/SlabOcean/utilities/boilerplate.jl
@@ -1,0 +1,74 @@
+using Dates
+using GaussQuadrature
+using JLD2
+using LinearAlgebra
+using Logging
+using MPI
+using Printf
+using StaticArrays
+using Test
+
+using ClimateMachine
+using ClimateMachine.Atmos: NoReferenceState
+using ClimateMachine.MPIStateArrays
+using ClimateMachine.VariableTemplates
+using ClimateMachine.Mesh.Geometry
+using ClimateMachine.Mesh.Topologies
+using ClimateMachine.Mesh.Grids
+using ClimateMachine.DGMethods
+using ClimateMachine.DGMethods.NumericalFluxes
+using ClimateMachine.BalanceLaws
+using ClimateMachine.ODESolvers
+using ClimateMachine.SystemSolvers
+using ClimateMachine.Orientations
+using ClimateMachine.VTK
+
+# to be removed
+using ClimateMachine.GenericCallbacks:
+    EveryXWallTimeSeconds, EveryXSimulationSteps
+using ClimateMachine.Thermodynamics: soundspeed_air
+using ClimateMachine.VariableTemplates: flattenednames
+
+# to be removed: needed for updating ref state
+import ClimateMachine.ODESolvers: update_backward_Euler_solver!
+import ClimateMachine.DGMethods: update_auxiliary_state!
+
+# to be removed
+using CLIMAParameters#: AbstractEarthParameterSet
+struct PlanetParameterSet <: AbstractEarthParameterSet end
+get_planet_parameter(p::Symbol) = getproperty(CLIMAParameters.Planet, p)(PlanetParameterSet())
+
+# utils
+include("../utilities/operations.jl")
+include("../utilities/sphere_utils.jl")
+# grid
+include("../grid/domains.jl")
+include("../grid/grids.jl")
+# numerics
+include("../models/models.jl")
+include("../numerics/filters.jl")
+# backends
+#include("../balance_law_interface.jl")
+include("../esdg_balance_law_interface.jl")
+include("../boundary_conditions/boundary_conditions.jl")
+include("../numerics/numerical_volume_fluxes.jl")
+include("../numerics/numerical_interface_fluxes.jl")
+include("../numerics/timestepper_abstractions.jl")
+include("../simulations.jl")
+include("../utilities/callbacks.jl")
+# physics
+include("../grid/orientations.jl")
+include("../physics/physics.jl")
+include("../physics/advection.jl")
+include("../physics/thermodynamics.jl")
+include("../physics/coriolis.jl")
+include("../physics/pressure_force.jl")
+include("../physics/gravity.jl")
+include("../physics/diffusion.jl")
+include("../physics/microphysics.jl")
+include("../physics/temperature_profiles.jl")
+# coupler
+include("../coupler/put_get_calls.jl")
+include("../coupler/surface_fluxes.jl")
+
+ClimateMachine.init()

--- a/experiments/SlabOcean/utilities/callbacks.jl
+++ b/experiments/SlabOcean/utilities/callbacks.jl
@@ -1,0 +1,282 @@
+abstract type AbstractCallback end
+
+struct Default <: AbstractCallback end
+struct Info <: AbstractCallback end
+struct CFL <: AbstractCallback end
+struct StateCheck{T} <: AbstractCallback
+    number_of_checks::T
+end
+
+Base.@kwdef struct JLD2State{T, V, B} <: AbstractCallback
+    iteration::T
+    filepath::V
+    overwrite::B = true
+end
+
+Base.@kwdef struct VTKState{T, V, C, B} <: AbstractCallback
+    iteration::T = 1
+    filepath::V = "."
+    counter::C = [0]
+    overwrite::B = true
+end
+
+Base.@kwdef struct TMARCallback{ℱ} <: AbstractCallback 
+    filterstates::ℱ = 6:6
+end
+
+Base.@kwdef struct ReferenceStateUpdate{ℱ} <: AbstractCallback 
+    recompute::ℱ = 20
+end
+
+function create_callbacks(simulation::Simulation, odesolver)
+    callbacks = simulation.callbacks
+
+    if isempty(callbacks)
+        return ()
+    else
+        cbvector = [
+            create_callback(callback, simulation, odesolver)
+            for callback in callbacks
+        ]
+        return tuple(cbvector...)
+    end
+end
+
+function create_callback(::Default, simulation::Simulation, odesolver)
+    cb_info = create_callback(Info(), simulation, odesolver)
+    cb_state_check = create_callback(StateCheck(10), simulation, odesolver)
+
+    return (cb_info, cb_state_check)
+end
+
+function create_callback(::Info, simulation::Simulation, odesolver)
+    Q = simulation.state
+    timeend = simulation.time.finish
+    mpicomm = MPI.COMM_WORLD
+
+    starttime = Ref(now())
+    cbinfo = ClimateMachine.GenericCallbacks.EveryXWallTimeSeconds(
+        60,
+        mpicomm,
+    ) do (s = false)
+        if s
+            starttime[] = now()
+        else
+            energy = norm(Q)
+            @info @sprintf(
+                """Update
+                simtime = %8.4f / %8.4f
+                runtime = %s
+                norm(Q) = %.16e""",
+                ClimateMachine.ODESolvers.gettime(odesolver),
+                timeend,
+                Dates.format(
+                    convert(Dates.DateTime, Dates.now() - starttime[]),
+                    Dates.dateformat"HH:MM:SS",
+                ),
+                energy
+            )
+
+            if isnan(energy)
+                error("NaNs")
+            end
+        end
+    end
+
+    return cbinfo
+end
+
+function create_callback(::CFL, simulation::Simulation, odesolver)
+    Q = simulation.state
+    # timeend = simulation.time.finish
+    # mpicomm = MPI.COMM_WORLD
+    # starttime = Ref(now())
+    cbcfl = EveryXSimulationSteps(100) do
+            simtime = gettime(odesolver)
+
+            @views begin
+                ρ = Array(Q.data[:, 1, :])
+                ρu = Array(Q.data[:, 2, :])
+                ρv = Array(Q.data[:, 3, :])
+                ρw = Array(Q.data[:, 4, :])
+            end
+
+            u = ρu ./ ρ
+            v = ρv ./ ρ
+            w = ρw ./ ρ
+
+            # TODO! transform onto sphere
+
+            ue = extrema(u)
+            ve = extrema(v)
+            we = extrema(w)
+
+            @info @sprintf """CFL
+                    simtime = %.16e
+                    u = (%.4e, %.4e)
+                    v = (%.4e, %.4e)
+                    w = (%.4e, %.4e)
+                    """ simtime ue... ve... we...
+        end
+
+    return cbcfl
+end
+
+function create_callback(callback::StateCheck, simulation::Simulation, _...)
+    sim_length = simulation.time.finish - simulation.time.start
+    timestep = simulation.timestepper.timestep
+    nChecks = callback.number_of_checks
+
+    nt_freq = floor(Int, sim_length / timestep / nChecks)
+
+    cbcs_dg = ClimateMachine.StateCheck.sccreate(
+        [(simulation.state, "state")],
+        nt_freq,
+    )
+
+    return cbcs_dg
+end
+
+function create_callback(output::JLD2State, simulation::Simulation, odesolver)
+    # Initialize output
+    output.overwrite &&
+        isfile(output.filepath) &&
+        rm(output.filepath; force = output.overwrite)
+
+    Q = simulation.state
+    mpicomm = MPI.COMM_WORLD
+    iteration = output.iteration
+
+    steps = ClimateMachine.ODESolvers.getsteps(odesolver)
+    time = ClimateMachine.ODESolvers.gettime(odesolver)
+
+    file = jldopen(output.filepath, "a+")
+    JLD2.Group(file, "state")
+    JLD2.Group(file, "time")
+    file["state"][string(steps)] = Array(Q)
+    file["time"][string(steps)] = time
+    close(file)
+
+
+    jldcallback = ClimateMachine.GenericCallbacks.EveryXSimulationSteps(
+        iteration,
+    ) do (s = false)
+        steps = ClimateMachine.ODESolvers.getsteps(odesolver)
+        time = ClimateMachine.ODESolvers.gettime(odesolver)
+        @info steps, time
+        file = jldopen(output.filepath, "a+")
+        file["state"][string(steps)] = Array(Q)
+        file["time"][string(steps)] = time
+        close(file)
+        return nothing
+    end
+
+    return jldcallback
+end
+
+function create_callback(output::VTKState, simulation::Simulation, odesolver)
+    # Initialize output
+    output.overwrite &&
+        isfile(output.filepath) &&
+        rm(output.filepath; force = output.overwrite)
+    mkpath(output.filepath)
+
+    state = simulation.state
+    if simulation.rhs isa Tuple
+        if simulation.rhs[1] isa AbstractRate 
+            model = simulation.rhs[1].model
+        else
+            model = simulation.rhs[1]
+        end
+    else
+        model = simulation.rhs
+    end
+    # model = (simulation.rhs isa Tuple) ? simulation.rhs[1] : simulation.rhs 
+
+    function do_output(counter, model, state)
+        mpicomm = MPI.COMM_WORLD
+        balance_law = model.balance_law
+        aux_state = model.state_auxiliary
+
+        outprefix = @sprintf(
+            "%s/mpirank%04d_step%04d",
+            output.filepath,
+            MPI.Comm_rank(mpicomm),
+            counter[1],
+        )
+
+        @info "doing VTK output" outprefix
+
+        state_names =
+            flattenednames(vars_state(balance_law, Prognostic(), eltype(state)))
+        aux_names =
+            flattenednames(vars_state(balance_law, Auxiliary(), eltype(state)))
+
+        writevtk(outprefix, state, model, state_names, aux_state, aux_names)
+
+        counter[1] += 1
+
+        return nothing
+    end
+
+    do_output(output.counter, model, state)
+    cbvtk =
+        ClimateMachine.GenericCallbacks.EveryXSimulationSteps(output.iteration) do (
+            init = false
+        )
+            do_output(output.counter, model, state)
+            return nothing
+        end
+
+    return cbvtk
+end
+
+function create_callback(filter::TMARCallback, simulation::Simulation, odesolver)
+    Q = simulation.state
+    grid = simulation.grid.numerical
+    tmar_filter = EveryXSimulationSteps(1) do
+        Filters.apply!(Q, filter.filterstates, grid, TMARFilter())
+        end
+    return tmar_filter
+end
+
+# helper function 
+
+function update_ref_state!(
+    model::DryAtmosModel,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    eos = model.physics.eos
+    parameters = model.physics.parameters
+    ρ = state.ρ
+    ρu = state.ρu
+    ρe = state.ρe
+    aux.ref_state.ρ = ρ
+    aux.ref_state.ρu = ρu # @SVector[0.0,0.0,0.0]
+    aux.ref_state.ρe = ρe
+
+    aux.ref_state.p = calc_pressure(eos, state, aux, parameters)
+end
+
+function create_callback(update_ref::ReferenceStateUpdate, simulation::Simulation, odesolver)
+    Q = simulation.state
+    grid = simulation.grid.numerical
+    step =  update_ref.recompute
+    dg = simulation.rhs[2].model
+    balance_law = dg.balance_law
+
+    relinearize = EveryXSimulationSteps(step) do       
+        t = gettime(odesolver)
+        
+        update_auxiliary_state!(update_ref_state!, dg, balance_law, Q, t)
+
+        α = odesolver.dt * odesolver.RKA_implicit[2, 2]
+        # hack
+        be_solver = odesolver.implicit_solvers[odesolver.RKA_implicit[2, 2]][1]
+        update_backward_Euler_solver!(be_solver, Q, α)
+        nothing
+    end
+    return relinearize
+end

--- a/experiments/SlabOcean/utilities/operations.jl
+++ b/experiments/SlabOcean/utilities/operations.jl
@@ -1,0 +1,2 @@
+⋅(a::SVector, b::SVector) = StaticArrays.dot(a, b)
+⊗(a::AbstractArray, b::AbstractArray) = a * b'

--- a/experiments/SlabOcean/utilities/sphere_utils.jl
+++ b/experiments/SlabOcean/utilities/sphere_utils.jl
@@ -1,0 +1,17 @@
+rad(x,y,z) = sqrt(x^2 + y^2 + z^2)
+lat(x,y,z) = asin(z/rad(x,y,z)) # ϕ ∈ [-π/2, π/2] 
+lon(x,y,z) = atan(y,x) # λ ∈ [-π, π) 
+
+r̂ⁿᵒʳᵐ(x,y,z) = norm([x,y,z]) ≈ 0 ? 1 : norm([x, y, z])^(-1)
+ϕ̂ⁿᵒʳᵐ(x,y,z) = norm([x,y,0]) ≈ 0 ? 1 : (norm([x, y, z]) * norm([x, y, 0]))^(-1)
+λ̂ⁿᵒʳᵐ(x,y,z) = norm([x,y,0]) ≈ 0 ? 1 : norm([x, y, 0])^(-1)
+
+r̂(x,y,z) = r̂ⁿᵒʳᵐ(x,y,z) * @SVector([x, y, z])
+ϕ̂(x,y,z) = ϕ̂ⁿᵒʳᵐ(x,y,z) * @SVector [x*z, y*z, -(x^2 + y^2)]
+λ̂(x,y,z) = λ̂ⁿᵒʳᵐ(x,y,z) * @SVector [-y, x, 0] 
+
+rfunc(p, x...) = ρuʳᵃᵈ(p, lon(x...), lat(x...), rad(x...)) * r̂(x...)
+ϕfunc(p, x...) = ρuˡᵃᵗ(p, lon(x...), lat(x...), rad(x...)) * ϕ̂(x...)
+λfunc(p, x...) = ρuˡᵒⁿ(p, lon(x...), lat(x...), rad(x...)) * λ̂(x...)
+
+ρu⃗(p, x...) = rfunc(p, x...) + ϕfunc(p, x...) + λfunc(p, x...)


### PR DESCRIPTION
Coupled GCM (Held-Suarez setup from RQA) with a shell slab ocean. This is the final piece of the test suite performed with the DGModel. 

Design:
- [README.md](https://github.com/CliMA/CouplerMachine/blob/ln/slabocean/experiments/SlabOcean/README.md)

Tests:
- conservation checks: dry SlabOcean w/o Held-Suarez forcing
    - [results (June 23 section)](https://docs.google.com/document/d/1JKK8wFKPq3Jo3D4flXZiY3WAUPqYE19pXRvwJgpDwjw/edit)
- physical checks: moist SlabOcean with Held-Suarez forcing
    - [results (July 9 section)](https://docs.google.com/document/d/1JKK8wFKPq3Jo3D4flXZiY3WAUPqYE19pXRvwJgpDwjw/edit)

Outstanding issues:
- diffusion can be added once available in the ESDGModel kernels
- currently, there is a bug in LMARS numerical fluxes, leading to conservation breaking at the boundary; as an alternative, Roe fluxes can be used (but their moist version is yet to be implemented, and in the dry case Roe fluxes have been found more unstable due to their less extreme smoothing at boundaries). Due to this issues, the above conservation tests were only performed on the dry setup with dry Roe fluxes. 